### PR TITLE
feat: add wormhole benchmark

### DIFF
--- a/metriq_gym/benchmarks/__init__.py
+++ b/metriq_gym/benchmarks/__init__.py
@@ -3,6 +3,7 @@ from metriq_gym.benchmarks.qml_kernel import QMLKernel, QMLKernelData
 from metriq_gym.benchmarks.clops import Clops, ClopsData
 from metriq_gym.benchmarks.quantum_volume import QuantumVolume, QuantumVolumeData
 from metriq_gym.benchmarks.bseq import BSEQ, BSEQData
+from metriq_gym.benchmarks.wormhole import Wormhole, WormholeData
 from metriq_gym.job_type import JobType
 
 BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
@@ -10,6 +11,7 @@ BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.CLOPS: Clops,
     JobType.QML_KERNEL: QMLKernel,
     JobType.QUANTUM_VOLUME: QuantumVolume,
+    JobType.WORMHOLE: Wormhole,
 }
 
 BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
@@ -17,6 +19,7 @@ BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
     JobType.CLOPS: ClopsData,
     JobType.QML_KERNEL: QMLKernelData,
     JobType.QUANTUM_VOLUME: QuantumVolumeData,
+    JobType.WORMHOLE: WormholeData,
 }
 
 SCHEMA_MAPPING = {
@@ -24,4 +27,5 @@ SCHEMA_MAPPING = {
     JobType.CLOPS: "clops.schema.json",
     JobType.QML_KERNEL: "qml_kernel.schema.json",
     JobType.QUANTUM_VOLUME: "quantum_volume.schema.json",
+    JobType.WORMHOLE: "wormhole.schema.json",
 }

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -107,7 +107,7 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
 
         # Measure qubit 0 into a classical bit, e.g., classical register bit 0
         # Corresponds to Pauli Z operator on qubit 0 (SparsePauliOp('ZIIIII')).
-        qc.measure(0, 0)
+        qc.measure(5, 0)
         return qc
 
     elif num_qubits == 7:

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -205,19 +205,16 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
 
 
 def calculate_expectation_value(num_qubits: int, shots: int, count_results: dict) -> float:
-    """Calculate the expectation value for a measured qubit specified by its index.
-
-    measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
-
-    Note: Qiskit's measurement results are in little-endian order so outcome[-(measured_qubit_index+1)] gives the bit
-    corresponding to that qubit.
-    """
+    """Calculate the expectation value for a measured qubit specified by its index."""
+    # measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
     if num_qubits == 6:
         measured_qubit_index = 0
     elif num_qubits == 7:
         measured_qubit_index = 1
 
     expectation = 0.0
+    # Note: Qiskit's measurement results are in little-endian order so outcome[-(measured_qubit_index+1)] gives the bit
+    # corresponding to that qubit.
     for outcome, count in count_results.items():
         bit = outcome[-(measured_qubit_index + 1)]
         eigenvalue = 1 if bit == "0" else -1
@@ -239,7 +236,7 @@ class WormholeResult(BenchmarkResult):
 
 @dataclass
 class WormholeData(BenchmarkData):
-    """Data class to store Wormhole benchmark metadata."""
+    """Dataclass to store Wormhole benchmark metadata."""
 
     pass
 

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -5,6 +5,9 @@ The Wormhole benchmark is based on the following paper:
     Towards Quantum Gravity in the Lab on Quantum Processors
     Illya Shapoval, Vincent Paul Su, Wibe de Jong, Miro Urbanek, Brian Swingle
     Quantum 7, 1138 (2023)
+
+A generalized version of the wormhole benchmark software can also be found as a companion [software
+repository](https://gitlab.com/ishapova/qglab/-/blob/master/scripts/wormhole.py) to the above paper.
 """
 
 import numpy as np
@@ -18,7 +21,12 @@ from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkR
 
 
 def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
-    """Create a wormhole circuit for either 6 or 7 qubits."""
+    """Create a wormhole circuit for either 6 or 7 qubits.
+
+    The 7-qubit circuit is based on the circuit diagram in Figure-4 of
+    [arXiv:2205.14081](https://arxiv.org/pdf/2205.14081). Both the 6- and 7-qubit circuits assume a interraction
+    coupling constant (referred to as `g` in the paper) of pi/2.
+    """
     if num_qubits == 6:
         qc = QuantumCircuit(6, 1)
         qc.h(0)
@@ -105,8 +113,8 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
         qc.rzz(np.pi / 2, 5, 4)
         qc.rzz(np.pi / 2, 4, 3)
 
-        # Measure qubit 0 into a classical bit, e.g., classical register bit 0
-        # Corresponds to Pauli Z operator on qubit 0 (SparsePauliOp('ZIIIII')).
+        # Perform a measurement which corresponds to the Pauli-Z operator (SparsePauliOp('ZIIIII')). Since Qiskit is
+        # little-endian, this is reversed, and the measurement is actually performed on the 5-th qubit.
         qc.measure(5, 0)
         return qc
 
@@ -196,8 +204,9 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
         qc.rzz(np.pi / 2, 5, 4)
         qc.rzz(np.pi / 2, 4, 3)
 
-        # Measure qubit 1 into a classical bit, e.g., classical register bit 0
-        # Corresponds to Pauli Z operator on qubit 1 (SparsePauliOp('IZIIIII')).
+        # Perform a measurement which corresponds to the Pauli-Z operator (SparsePauliOp('IZIIIII')). Since Qiskit is
+        # little-endian, this is reversed, and the measurement is actually performed on the 5-th qubit. This can also
+        # be seen in Figure-4 of the paper.
         qc.measure(5, 0)
 
         return qc
@@ -206,7 +215,8 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
 
 
 def calculate_expectation_value(shots: int, count_results: MeasCount) -> float:
-    return count_results['1'] / shots
+    """Calculate the expectation value of the Pauli operator in the state produced by the quantum circuit."""
+    return count_results["1"] / shots
 
 
 @dataclass

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -205,23 +205,8 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
         raise ValueError(f"Unsupported number of qubits: {num_qubits}")
 
 
-def calculate_expectation_value(num_qubits: int, shots: int, count_results: MeasCount) -> float:
-    """Calculate the expectation value for a measured qubit specified by its index."""
-    # The measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
-    if num_qubits == 6:
-        measured_qubit_index = 0
-    elif num_qubits == 7:
-        measured_qubit_index = 1
-
-    expectation = 0.0
-    # Note: Qiskit's measurement results are in little-endian order so outcome[-(measured_qubit_index+1)] gives the bit
-    # corresponding to that qubit.
-    for outcome, count in count_results.items():
-        bit = outcome[-(measured_qubit_index + 1)]
-        eigenvalue = 1 if bit == "0" else -1
-        expectation += eigenvalue * count
-    expectation /= shots
-    return expectation
+def calculate_expectation_value(shots: int, count_results: MeasCount) -> float:
+    return count_results['1'] / shots
 
 
 @dataclass

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -198,7 +198,7 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
 
         # Measure qubit 1 into a classical bit, e.g., classical register bit 0
         # Corresponds to Pauli Z operator on qubit 1 (SparsePauliOp('IZIIIII')).
-        qc.measure(1, 0)
+        qc.measure(5, 0)
 
         return qc
     else:

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -246,6 +246,6 @@ class Wormhole(Benchmark):
         """Poll results for Wormhole benchmark."""
         return WormholeResult(
             expectation_value=calculate_expectation_value(
-                self.params.num_qubits, self.params.shots, flatten_counts(result_data)[0]
+                self.params.shots, flatten_counts(result_data)[0]
             )
         )

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -1,0 +1,268 @@
+"""Wormhole benchmark for the Metriq Gym
+(credit to Paul Nation for the original code for IBM devices).
+
+The Wormhole benchmark is based on the following paper:
+    Towards Quantum Gravity in the Lab on Quantum Processors
+    Illya Shapoval, Vincent Paul Su, Wibe de Jong, Miro Urbanek, Brian Swingle
+    Quantum 7, 1138 (2023)
+"""
+
+import numpy as np
+from dataclasses import dataclass
+
+from qiskit import QuantumCircuit
+from qbraid import GateModelResultData, QuantumDevice, QuantumJob
+from metriq_gym.helpers.task_helpers import flatten_counts, flatten_job_ids
+from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
+
+
+def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
+    """Create a wormhole circuit for either 6 or 7 qubits."""
+    if num_qubits == 6:
+        qc = QuantumCircuit(6, 1)
+        qc.h(0)
+        qc.cx(0, 5)
+        qc.h(1)
+        qc.cx(1, 4)
+        qc.h(2)
+        qc.cx(2, 3)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.reset(0)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        # Here are the two RZZ gates that are parameterized
+        qc.rzz(np.pi / 2, 1, 4)
+        qc.rzz(np.pi / 2, 2, 3)
+        # -------------------------------------------------
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+
+        # Measure qubit 0 into a classical bit, e.g., classical register bit 0
+        # Corresponds to Pauli Z operator on qubit 0 (SparsePauliOp('ZIIIII')).
+        qc.measure(0, 0)
+        return qc
+
+    elif num_qubits == 7:
+        qc = QuantumCircuit(7, 1)
+        qc.h(0)
+        qc.cx(0, 5)
+        qc.h(1)
+        qc.cx(1, 4)
+        qc.h(2)
+        qc.cx(2, 3)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.rx(-np.pi / 2, 0)
+        qc.rx(-np.pi / 2, 1)
+        qc.rx(-np.pi / 2, 2)
+        qc.rz(-0.0566794, 0)
+        qc.rz(-0.01039906, 1)
+        qc.rz(-0.0632158, 2)
+        qc.rzz(-np.pi / 2, 0, 1)
+        qc.rzz(-np.pi / 2, 1, 2)
+        qc.swap(0, 6)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        qc.rz(0.0566794, 0)
+        qc.rz(0.01039906, 1)
+        qc.rz(0.0632158, 2)
+        qc.rzz(np.pi / 2, 0, 1)
+        qc.rzz(np.pi / 2, 1, 2)
+        qc.rx(np.pi / 2, 0)
+        qc.rx(np.pi / 2, 1)
+        qc.rx(np.pi / 2, 2)
+        # Here are the two RZZ gates that are parameterized
+        qc.rzz(np.pi / 2, 1, 4)
+        qc.rzz(np.pi / 2, 2, 3)
+        # -------------------------------------------------
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+        qc.rx(np.pi / 2, 5)
+        qc.rx(np.pi / 2, 4)
+        qc.rx(np.pi / 2, 3)
+        qc.rz(0.0566794, 5)
+        qc.rz(0.01039906, 4)
+        qc.rz(0.0632158, 3)
+        qc.rzz(np.pi / 2, 5, 4)
+        qc.rzz(np.pi / 2, 4, 3)
+
+        # Measure qubit 1 into a classical bit, e.g., classical register bit 0
+        # Corresponds to Pauli Z operator on qubit 1 (SparsePauliOp('IZIIIII')).
+        qc.measure(1, 0)
+
+        return qc
+    else:
+        raise ValueError(f"Unsupported number of qubits: {num_qubits}")
+
+
+def calculate_expectation_value(num_qubits: int, shots: int, count_results: dict) -> float:
+    """Calculate the expectation value for a measured qubit specified by its index.
+
+    measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
+
+    Note: Qiskit's measurement results are in little-endian order so outcome[-(measured_qubit_index+1)] gives the bit
+    corresponding to that qubit.
+    """
+    if num_qubits == 6:
+        measured_qubit_index = 0
+    elif num_qubits == 7:
+        measured_qubit_index = 1
+
+    expectation = 0.0
+    for outcome, count in count_results.items():
+        bit = outcome[-(measured_qubit_index + 1)]
+        eigenvalue = 1 if bit == "0" else -1
+        expectation += eigenvalue * count
+    expectation /= shots
+    return expectation
+
+
+@dataclass
+class WormholeResult(BenchmarkResult):
+    """Result class to store Wormhole benchmark results.
+
+    Attributes:
+        expectation_value: Expectation value of the Pauli operator in the state produced by the quantum circuit.
+    """
+
+    expectation_value: float
+
+
+@dataclass
+class WormholeData(BenchmarkData):
+    """Data class to store Wormhole benchmark metadata."""
+
+    pass
+
+
+class Wormhole(Benchmark):
+    """Benchmark class for Wormhole experiments."""
+
+    def dispatch_handler(self, device: QuantumDevice) -> WormholeData:
+        """Runs the benchmark and returns job metadata."""
+        quantum_job: QuantumJob | list[QuantumJob] = device.run(
+            wormhole_circuit(self.params.num_qubits), shots=self.params.shots
+        )
+        return WormholeData(provider_job_ids=flatten_job_ids(quantum_job))
+
+    def poll_handler(
+        self,
+        job_data: WormholeData,
+        result_data: list[GateModelResultData],
+        quantum_jobs: list[QuantumJob],
+    ) -> WormholeResult:
+        """Poll results for Wormhole benchmark."""
+        return WormholeResult(
+            expectation_value=calculate_expectation_value(
+                self.params.num_qubits, self.params.shots, flatten_counts(result_data)[0]
+            )
+        )

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 from qiskit import QuantumCircuit
 from qbraid import GateModelResultData, QuantumDevice, QuantumJob
+from qbraid.runtime.result_data import MeasCount
 from metriq_gym.helpers.task_helpers import flatten_counts, flatten_job_ids
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
 
@@ -204,9 +205,9 @@ def wormhole_circuit(num_qubits: int) -> QuantumCircuit:
         raise ValueError(f"Unsupported number of qubits: {num_qubits}")
 
 
-def calculate_expectation_value(num_qubits: int, shots: int, count_results: dict) -> float:
+def calculate_expectation_value(num_qubits: int, shots: int, count_results: MeasCount) -> float:
     """Calculate the expectation value for a measured qubit specified by its index."""
-    # measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
+    # The measured_qubit_index: 0 corresponds to qubit0, 1 to qubit1, etc.
     if num_qubits == 6:
         measured_qubit_index = 0
     elif num_qubits == 7:

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -219,7 +219,6 @@ def calculate_expectation_value(shots: int, count_results: MeasCount) -> float:
     return count_results["1"] / shots
 
 
-@dataclass
 class WormholeResult(BenchmarkResult):
     """Result class to store Wormhole benchmark results.
 

--- a/metriq_gym/job_type.py
+++ b/metriq_gym/job_type.py
@@ -6,3 +6,4 @@ class JobType(StrEnum):
     CLOPS = "CLOPS"
     QML_KERNEL = "QML Kernel"
     QUANTUM_VOLUME = "Quantum Volume"
+    WORMHOLE = "Wormhole"

--- a/metriq_gym/schemas/examples/wormhole.example.json
+++ b/metriq_gym/schemas/examples/wormhole.example.json
@@ -1,0 +1,6 @@
+{
+    "benchmark_name": "Wormhole",
+    "num_qubits": 6,
+    "shots": 10
+}
+  

--- a/metriq_gym/schemas/examples/wormhole.example.json
+++ b/metriq_gym/schemas/examples/wormhole.example.json
@@ -1,6 +1,6 @@
 {
     "benchmark_name": "Wormhole",
-    "num_qubits": 6,
-    "shots": 10
+    "num_qubits": 7,
+    "shots": 8192
 }
   

--- a/metriq_gym/schemas/wormhole.schema.json
+++ b/metriq_gym/schemas/wormhole.schema.json
@@ -1,0 +1,30 @@
+{
+    "$id": "metriq-gym/wormhole.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",  
+    "title": "Wormhole",
+    "description": "The Wormhole benchmark schema definition, describing the Wormhole benchmark configuration.",
+    "type": "object",
+    "properties": {
+      "benchmark_name": {
+        "type": "string",
+        "const": "Wormhole",
+        "description": "Name of the benchmark. Must be 'Wormhole' for this schema."
+      },
+      "shots": {
+        "type": "integer",
+        "description": "Number of measurement shots (repetitions) to use for the benchmark.",
+        "default": 1000,
+        "minimum": 1,
+        "examples": [1000]
+      },
+      "num_qubits": {
+        "type": "integer",
+        "description": "Number of qubits to use for the benchmark. Must be either 6 or 7.",
+        "enum": [6, 7],
+        "default": 6,
+        "examples": [6, 7]
+      }
+    },
+    "required": ["benchmark_name"]
+  }
+  


### PR DESCRIPTION
Closes: #62 

- Adds the wormhole benchmark from [arXiv:2205.14081](https://arxiv.org/abs/2205.14081) as provided via the Python reference implementation by @nonhermitian. 

For instance, dispatching and polling on the `ibm_sherbrooke` device using the following configuration:

```
{
    "benchmark_name": "Wormhole",
    "num_qubits": 6,
    "shots": 10
}
```

yields an expectation value outcome of:

```
WormholeResult(expectation_value=-0.6)
```

Note that the negative result is expected and means that the average over measurement shots is –0.6. This is expected if, for instance, about 80% of measurements yield the eigenvalue –1 (from |1⟩) and 20% yield +1 (from |0⟩). There is nothing inherently “wrong” with a negative expectation value—it just reflects the distribution of outcomes for your prepared state.