### PR TITLE
refactor: absorb job_type into benchmark init.

### DIFF
--- a/docs/source/adding_new_benchmark.rst
+++ b/docs/source/adding_new_benchmark.rst
@@ -130,13 +130,12 @@ This file offers a reference for developers and users on how to structure the JS
 Registering the New Benchmark
 *****************************
 
-1. **Add to job_type.py**
+1. **Add to benchmarks/__init__.py**
 
-   Open the :file:`metriq_gym/job_type.py` file and register your new benchmark in the :code:`JobType` enumeration:
+   Open the :file:`metriq_gym/benchmarks/__init__.py` file and register your new benchmark in the :code:`JobType` enumeration:
 
    .. code-block:: python
 
-       from metriq_gym.job_type import JobType
        from enum import StrEnum
 
        class JobType(StrEnum):
@@ -152,7 +151,7 @@ Registering the New Benchmark
        from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData
        from metriq_gym.benchmarks.new_benchmark import NewBenchmark, NewBenchmarkData
        ...
-       from metriq_gym.job_type import JobType
+
 
        BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
            JobType.NEW_BENCHMARK: NewBenchmark,

--- a/metriq_gym/benchmarks/__init__.py
+++ b/metriq_gym/benchmarks/__init__.py
@@ -1,9 +1,18 @@
+from enum import StrEnum
+
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData
 from metriq_gym.benchmarks.qml_kernel import QMLKernel, QMLKernelData
 from metriq_gym.benchmarks.clops import Clops, ClopsData
 from metriq_gym.benchmarks.quantum_volume import QuantumVolume, QuantumVolumeData
 from metriq_gym.benchmarks.bseq import BSEQ, BSEQData
-from metriq_gym.job_type import JobType
+
+
+class JobType(StrEnum):
+    BSEQ = "BSEQ"
+    CLOPS = "CLOPS"
+    QML_KERNEL = "QML Kernel"
+    QUANTUM_VOLUME = "Quantum Volume"
+
 
 BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.BSEQ: BSEQ,

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -6,7 +6,7 @@ import pprint
 from typing import Any
 
 from tabulate import tabulate
-from metriq_gym.job_type import JobType
+from metriq_gym.benchmarks import JobType
 
 
 @dataclass

--- a/metriq_gym/job_type.py
+++ b/metriq_gym/job_type.py
@@ -1,8 +1,0 @@
-from enum import StrEnum
-
-
-class JobType(StrEnum):
-    BSEQ = "BSEQ"
-    CLOPS = "CLOPS"
-    QML_KERNEL = "QML Kernel"
-    QUANTUM_VOLUME = "Quantum Volume"

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -23,7 +23,7 @@ from metriq_gym.cli import parse_arguments, prompt_for_job
 from metriq_gym.exceptions import QBraidSetupError
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.schema_validator import load_and_validate, validate_and_create_model
-from metriq_gym.job_type import JobType
+from metriq_gym.benchmarks import JobType
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("metriq_gym")

--- a/metriq_gym/schema_validator.py
+++ b/metriq_gym/schema_validator.py
@@ -4,8 +4,7 @@ from typing import Any
 from jsonschema import validate
 from pydantic import BaseModel, create_model
 
-from metriq_gym.benchmarks import SCHEMA_MAPPING
-from metriq_gym.job_type import JobType
+from metriq_gym.benchmarks import SCHEMA_MAPPING, JobType
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,8 @@ from tabulate import tabulate
 import pytest
 from unittest.mock import MagicMock
 from metriq_gym.cli import LIST_JOBS_HEADERS, list_jobs
+from metriq_gym.benchmarks import JobType
 from metriq_gym.job_manager import JobManager, MetriqGymJob
-from metriq_gym.job_type import JobType
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes: #294 

- Moved contents from `job_type.py` and moved to `benchmarks/__init__.py`.
- Updated docs of adding benchmark to reflect this change.