### PR TITLE
refactor: change so rebase can update branch

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,6 +1,7 @@
 # Adapted from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
 
 permissions:
   contents: write
@@ -9,18 +10,30 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'unitaryfoundation/metriq-gym'
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'unitaryfoundation/metriq-gym'
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve Dependabot PRs and enable auto-merge for them 
+
+      - name: Ask Dependabot to rebase (if needed)
+        if: steps.metadata.outputs.has-conflicts == 'true'
+        uses: bbeesley/gha-auto-dependabot-rebase@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve Dependabot PRs and enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes: #308 

- `actions/checkout@v4` so the rebase action can update the branch.
- A rebase step that runs only if Dependabot’s metadata shows merge conflicts.
- The approve + auto-merge step remains gated on semver-patch updates.