### PR TITLE
added status for jobs which are not completed #238

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ In the event where the job has not completed, we would receive the following mes
 
 ```sh
 INFO - Polling job...
-INFO - Job is not yet completed. Please try again later.
+INFO - Job is not yet completed. Current status:
+INFO - - 93a06a18-41d8-475a-a030-339fbf3accb9: QUEUED (position 3)
+INFO - Please try again later.
 ```
 
 As a convenience, while we could supply the metriq-gym job ID, we can also poll the job by running `mgym poll` and then selecting the job to poll by index from our local metriq-gym jobs database.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ In the event where the job has not completed, we would receive the following mes
 ```sh
 INFO - Polling job...
 INFO - Job is not yet completed. Current status:
-INFO - - 93a06a18-41d8-475a-a030-339fbf3accb9: QUEUED (position 3)
+INFO - - d0wtyfhvx7bg008203b0: QUEUED (position 3)
 INFO - Please try again later.
 ```
 

--- a/metriq_gym/qplatform/__init__.py
+++ b/metriq_gym/qplatform/__init__.py
@@ -6,6 +6,8 @@ access to metadata and introspection utilities for quantum computing platforms.
 
 It defines generic functions (using singledispatch) to fetch various metadata or
 properties, such as backend versions, coupling graphs, provider details, and job metadata.
+Job metadata includes execution time and provider-specific status information such
+as queue position when available.
 
 It builds on top of qBraid's runtime module, and in the future,
 functions defined here may be upstreamed to qBraid's runtime module.

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -58,6 +58,8 @@ def extract_status_info(quantum_job: QuantumJob, supports_queue_position: bool) 
     queue_position = None
     if supports_queue_position:
         for attr in ["queue_position", "queue_info"]:
+            # These attributes are defined in qBraid provider job classes (e.g., QiskitJob, BraketQuantumTask).
+            # Reference: https://github.com/qBraid/qBraid/tree/main/qbraid/runtime
             if hasattr(quantum_job, attr):
                 try:
                     info = getattr(quantum_job, attr)

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from functools import singledispatch
 
 from qbraid import QuantumJob
@@ -33,3 +34,74 @@ def _(quantum_job: BraketQuantumTask) -> float:
     return (
         quantum_job._task.metadata()["endedAt"] - quantum_job._task.metadata()["createdAt"]
     ).total_seconds()
+
+@dataclass
+class JobStatusInfo:
+    """Provider agnostic job status information."""
+
+    status: str
+    queue_position: int | None = None
+
+
+@singledispatch
+def job_status(quantum_job: QuantumJob) -> JobStatusInfo:
+    """Return the provider specific status and queue position if available."""
+    try:
+        status_obj = quantum_job.status()
+        status = getattr(status_obj, "name", str(status_obj))
+    except Exception:
+        status = "UNKNOWN"
+    queue_position = None
+    for attr in ["queue_position", "queue_info", "queue_position_retrieval"]:
+        if hasattr(quantum_job, attr):
+            try:
+                info = getattr(quantum_job, attr)
+                info = info() if callable(info) else info
+                if hasattr(info, "position"):
+                    info = info.position
+                if info is not None:
+                    queue_position = int(info)
+                break
+            except Exception:
+                pass
+    return JobStatusInfo(status=status, queue_position=queue_position)
+
+
+@job_status.register
+def _(quantum_job: QiskitJob) -> JobStatusInfo:
+    status = getattr(quantum_job._job.status(), "name", str(quantum_job._job.status()))
+    queue_position = None
+    if hasattr(quantum_job._job, "queue_position"):
+        try:
+            queue_position = quantum_job._job.queue_position()
+        except Exception:
+            queue_position = None
+    elif hasattr(quantum_job._job, "queue_info"):
+        try:
+            info = quantum_job._job.queue_info()
+            if info:
+                queue_position = info.position
+        except Exception:
+            queue_position = None
+    return JobStatusInfo(status=status, queue_position=queue_position)
+
+
+@job_status.register
+def _(quantum_job: AzureQuantumJob) -> JobStatusInfo:
+    status_obj = getattr(quantum_job._job.details, "status", None)
+    status = getattr(status_obj, "name", str(status_obj)) if status_obj else "UNKNOWN"
+    queue_position = getattr(quantum_job._job.details, "current_queue_position", None)
+    return JobStatusInfo(status=status, queue_position=queue_position)
+
+
+@job_status.register
+def _(quantum_job: BraketQuantumTask) -> JobStatusInfo:
+    status_obj = None
+    try:
+        status_obj = quantum_job._task.state()
+    except Exception:
+        pass
+    status = getattr(status_obj, "name", str(status_obj)) if status_obj else "UNKNOWN"
+    queue_position = getattr(quantum_job._task, "queue_position", None)
+    return JobStatusInfo(status=status, queue_position=queue_position)
+

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -35,6 +35,7 @@ def _(quantum_job: BraketQuantumTask) -> float:
         quantum_job._task.metadata()["endedAt"] - quantum_job._task.metadata()["createdAt"]
     ).total_seconds()
 
+
 @dataclass
 class JobStatusInfo:
     """Provider agnostic job status information."""
@@ -43,65 +44,48 @@ class JobStatusInfo:
     queue_position: int | None = None
 
 
-@singledispatch
-def job_status(quantum_job: QuantumJob) -> JobStatusInfo:
-    """Return the provider specific status and queue position if available."""
+def extract_status_info(quantum_job: QuantumJob, supports_queue_position: bool) -> JobStatusInfo:
+    """Helper to extract job status and optionally queue position."""
     try:
         status_obj = quantum_job.status()
         status = getattr(status_obj, "name", str(status_obj))
     except Exception:
         status = "UNKNOWN"
+
     queue_position = None
-    for attr in ["queue_position", "queue_info", "queue_position_retrieval"]:
-        if hasattr(quantum_job, attr):
-            try:
-                info = getattr(quantum_job, attr)
-                info = info() if callable(info) else info
-                if hasattr(info, "position"):
-                    info = info.position
-                if info is not None:
-                    queue_position = int(info)
-                break
-            except Exception:
-                pass
+    if supports_queue_position:
+        for attr in ["queue_position", "queue_info"]:
+            if hasattr(quantum_job, attr):
+                try:
+                    info = getattr(quantum_job, attr)
+                    info = info() if callable(info) else info
+                    if hasattr(info, "position"):
+                        info = info.position
+                    if info is not None:
+                        queue_position = int(info)
+                    break
+                except Exception:
+                    continue
+
     return JobStatusInfo(status=status, queue_position=queue_position)
+
+
+@singledispatch
+def job_status(quantum_job: QuantumJob) -> JobStatusInfo:
+    """Fallback for unknown provider types: status only."""
+    return extract_status_info(quantum_job, supports_queue_position=False)
 
 
 @job_status.register
 def _(quantum_job: QiskitJob) -> JobStatusInfo:
-    status = getattr(quantum_job._job.status(), "name", str(quantum_job._job.status()))
-    queue_position = None
-    if hasattr(quantum_job._job, "queue_position"):
-        try:
-            queue_position = quantum_job._job.queue_position()
-        except Exception:
-            queue_position = None
-    elif hasattr(quantum_job._job, "queue_info"):
-        try:
-            info = quantum_job._job.queue_info()
-            if info:
-                queue_position = info.position
-        except Exception:
-            queue_position = None
-    return JobStatusInfo(status=status, queue_position=queue_position)
-
-
-@job_status.register
-def _(quantum_job: AzureQuantumJob) -> JobStatusInfo:
-    status_obj = getattr(quantum_job._job.details, "status", None)
-    status = getattr(status_obj, "name", str(status_obj)) if status_obj else "UNKNOWN"
-    queue_position = getattr(quantum_job._job.details, "current_queue_position", None)
-    return JobStatusInfo(status=status, queue_position=queue_position)
+    return extract_status_info(quantum_job, supports_queue_position=True)
 
 
 @job_status.register
 def _(quantum_job: BraketQuantumTask) -> JobStatusInfo:
-    status_obj = None
-    try:
-        status_obj = quantum_job._task.state()
-    except Exception:
-        pass
-    status = getattr(status_obj, "name", str(status_obj)) if status_obj else "UNKNOWN"
-    queue_position = getattr(quantum_job._task, "queue_position", None)
-    return JobStatusInfo(status=status, queue_position=queue_position)
+    return extract_status_info(quantum_job, supports_queue_position=True)
 
+
+@job_status.register
+def _(quantum_job: AzureQuantumJob) -> JobStatusInfo:
+    return extract_status_info(quantum_job, supports_queue_position=False)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -118,7 +118,7 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         print("Job is not yet completed. Current status:")
         for task in quantum_jobs:
             info = job_status(task)
-            msg = f"- {task.id}: {info.status}"
+            msg = f"- {metriq_job.id}: {info.status}"
             if info.queue_position is not None:
                 msg += f" (position {info.queue_position})"
             print(msg)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -118,7 +118,7 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         print("Job is not yet completed. Current status:")
         for task in quantum_jobs:
             info = job_status(task)
-            msg = f"- {metriq_job.id}: {info.status}"
+            msg = f"- {task.id}: {info.status}"
             if info.queue_position is not None:
                 msg += f" (position {info.queue_position})"
             print(msg)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -24,6 +24,7 @@ from metriq_gym.exceptions import QBraidSetupError
 from metriq_gym.exporters.cli_exporter import CliExporter
 from metriq_gym.exporters.json_exporter import JsonExporter
 from metriq_gym.job_manager import JobManager, MetriqGymJob
+from metriq_gym.qplatform.job import job_status
 from metriq_gym.schema_validator import load_and_validate, validate_and_create_model
 from metriq_gym.benchmarks import JobType
 
@@ -114,7 +115,14 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         else:
             CliExporter(metriq_job, results).export()
     else:
-        print("Job is not yet completed. Please try again later.")
+        print("Job is not yet completed. Current status:")
+        for task in quantum_jobs:
+            info = job_status(task)
+            msg = f"- {task.id}: {info.status}"
+            if info.queue_position is not None:
+                msg += f" (position {info.queue_position})"
+            print(msg)
+        print("Please try again later.")
 
 
 def view_job(args: argparse.Namespace, job_manager: JobManager) -> None:

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -118,7 +118,7 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         print("Job is not yet completed. Current status:")
         for task in quantum_jobs:
             info = job_status(task)
-            msg = f"- {task.id}: {info.status}"
+            msg = f"- {task.id}: {info.status.value}"
             if info.queue_position is not None:
                 msg += f" (position {info.queue_position})"
             print(msg)

--- a/tests/qplatform/test_job.py
+++ b/tests/qplatform/test_job.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 import pytest
 from qbraid.runtime import QuantumJob, QiskitJob
-from metriq_gym.qplatform.job import execution_time
+from metriq_gym.qplatform.job import execution_time, job_status
 from datetime import datetime, timedelta
 
 
@@ -20,3 +20,19 @@ def test_execution_time_unsupported():
     mock_job = MagicMock(spec=QuantumJob)
     with pytest.raises(NotImplementedError):
         execution_time(mock_job)
+
+
+def test_job_status_incomplete():
+    """Verify provider specific status and queue position are reported."""
+    status_obj = MagicMock()
+    status_obj.name = "QUEUED"
+
+    qiskit_job = MagicMock(spec=QiskitJob)
+    qiskit_job._job = MagicMock()
+    qiskit_job._job.status.return_value = status_obj
+    qiskit_job._job.queue_position.return_value = 3
+
+    info = job_status(qiskit_job)
+
+    assert info.status == "QUEUED"
+    assert info.queue_position == 3


### PR DESCRIPTION
# Description
This update introduces a provider‑agnostic utility for retrieving job status details, including queue position, and integrates it into the CLI.

- `JobStatusInfo` dataclass and `job_status` dispatcher centralize provider-specific status handling

- The CLI now displays each provider job’s status and queue position when polling incomplete jobs

- README example updated to show the new polling output with queue position details

- Module documentation notes that job metadata includes provider-specific queue information


fixes #238 
