### PR TITLE
lenient on handling invalid jsonl #301

### DIFF
--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -3,10 +3,13 @@ from datetime import datetime
 import json
 import os
 import pprint
+import logging
 from typing import Any
 
 from tabulate import tabulate
 from metriq_gym.benchmarks import JobType
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -64,12 +67,17 @@ class JobManager:
         self.jobs = []
         if os.path.exists(self.jobs_file):
             with open(self.jobs_file) as file:
-                for line in file:
+                for line_no, line in enumerate(file, start=1):
                     try:
                         job = MetriqGymJob.deserialize(line.strip())
                         self.jobs.append(job)
-                    except json.JSONDecodeError:
-                        continue
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "Skipping invalid job entry on line %d of %s: %s",
+                            line_no,
+                            self.jobs_file,
+                            exc,
+                        )
 
     def add_job(self, job: MetriqGymJob) -> str:
         self.jobs.append(job)

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -63,35 +63,61 @@ class JobManager:
     def __init__(self):
         self._load_jobs()
 
+    def _log_skip(self, line_number: int, reason: str) -> None:
+        logger.warning(f"Skipping job on line {line_number} in {self.jobs_file}: {reason}")
+
     def _load_jobs(self):
+        """
+        Initialize the job list by loading valid jobs from the local JSONL file.
+
+        This method reads the `.metriq_gym_jobs.jsonl` file line by line, 
+        attempting to deserialize each entry into a `MetriqGymJob` object. 
+        It skips invalid or outdated entries without raising exceptions,
+        while logging the reasons for each skip.
+
+        Jobs may be skipped for the following reasons:
+        - JSON decoding errors
+        - Missing required fields
+        - Invalid job types not defined in `JobType`
+        - Incorrect datetime format
+        - Structural mismatches or unsupported schemas
+
+        All successfully parsed jobs are stored in `self.jobs`.
+        """
         self.jobs = []
-        if os.path.exists(self.jobs_file):
-            with open(self.jobs_file) as file:
-                for line_number, line in enumerate(file, start=0):  
-                    stripped_line = line.strip()
-                    if not stripped_line:
-                        continue
-                    try:
-                        job = MetriqGymJob.deserialize(stripped_line)
 
-                        if not isinstance(getattr(job, "job_type", None), JobType):
-                            raise ValueError("Invalid or missing job_type")
+        if not os.path.exists(self.jobs_file):
+            return
 
-                        if not isinstance(getattr(job, "params", None), dict):
-                            raise TypeError("Invalid or missing params")
+        with open(self.jobs_file) as file:
+            for line_number, raw_line in enumerate(file, start=1):
+                stripped_line = raw_line.strip()
+                if not stripped_line:
+                    continue  # Ignore blank lines
 
-                        if not isinstance(getattr(job, "device_name", None), str):
-                            raise ValueError("Invalid or missing device_name")
-
-                        self.jobs.append(job)
-
-                    except json.JSONDecodeError as e:
-                        logger.warning(f"Line {line_number}: Invalid JSON (pos {e.pos})")
-                    except (KeyError, TypeError, ValueError) as e:
-                        logger.warning(f"Line {line_number}: {e}")
-                    except Exception as e:
-                        logger.warning(f"Line {line_number}: Unexpected error ({type(e).__name__}) - {e}")
-
+                try:
+                    job = MetriqGymJob.deserialize(stripped_line)
+                except json.JSONDecodeError as e:
+                    self._log_skip(line_number, f"Invalid JSON at position {e.pos}")
+                except KeyError as e:
+                    self._log_skip(line_number, f"Missing required field: {e}")
+                except ValueError as e:
+                    message = str(e).lower()
+                    if "not a valid" in message and "jobtype" in message:
+                        # Attempt to extract the invalid enum value
+                        invalid_value = str(e).split("'")[1] if "'" in str(e) else str(e)
+                        self._log_skip(line_number, f"Unknown job type: '{invalid_value}'")
+                    elif "datetime" in message or "time" in message:
+                        self._log_skip(line_number, f"Invalid datetime format: {e}")
+                    else:
+                        self._log_skip(line_number, f"Invalid value: {e}")
+                except TypeError as e:
+                    self._log_skip(line_number, f"Data structure mismatch: {e}")
+                except Exception as e:
+                    logger.warning(line_number, f"Unexpected exception ({type(e).__name__}): {e}")
+                else:
+                    self.jobs.append(job)
+       
         if not self.jobs:
             logger.warning(f"No valid jobs found in {self.jobs_file}.")
 

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -60,4 +60,4 @@ def test_load_jobs_skips_invalid(job_manager, sample_job, caplog):
     jobs = new_job_manager.get_jobs()
     assert len(jobs) == 1
     assert jobs[0].id == sample_job.id
-    assert "Skipping invalid job entry" in caplog.text
+    assert "invalid" in caplog.text

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 import pytest
+import json
 import logging
 from datetime import datetime
 from metriq_gym.job_manager import JobManager, MetriqGymJob
@@ -51,13 +52,112 @@ def test_load_jobs_with_existing_data(job_manager, sample_job):
     assert jobs[0].id == sample_job.id
 
 
-def test_load_jobs_skips_invalid(job_manager, sample_job, caplog):
-    job_manager.add_job(sample_job)
-    with open(JobManager.jobs_file, "a") as f:
-        f.write('{"id": "invalid"}\n')
+
+def test_mixed_valid_and_invalid_jobs_are_handled_gracefully(tmpdir, caplog):
+    """
+    Test that JobManager loads only valid jobs from a file containing a mix
+    of valid and invalid entries, and logs appropriate warnings for each invalid entry.
+    """
+    jobs_file = tmpdir.join("mixed_jobs.jsonl")
+    JobManager.jobs_file = str(jobs_file)
+
+    # Prepare job entries
+    valid_job_1 = MetriqGymJob(
+        id="valid_job_1",
+        provider_name="provider_1",
+        device_name="device_1",
+        job_type=FakeJobType(FAKE_BENCHMARK_NAME),
+        params={},
+        data={"provider_job_ids": []},
+        dispatch_time=datetime.now(),
+    )
+    valid_job_2 = MetriqGymJob(
+        id="valid_job_2",
+        provider_name="provider_2",
+        device_name="device_2",
+        job_type=FakeJobType(FAKE_BENCHMARK_NAME),
+        params={},
+        data={"provider_job_ids": []},
+        dispatch_time=datetime.now(),
+    )
+
+    with open(jobs_file, "w") as f:
+        f.write(valid_job_1.serialize() + "\n")                     # Valid
+        f.write("\n")                                               # Empty line
+        f.write('{"invalid": "json", "missing": true\n')            # Malformed JSON
+        f.write(json.dumps({                                        # Missing fields
+            "id": "missing_fields",
+            "params": {},
+            "data": {},
+            "provider_name": "test"
+        }) + "\n")
+        f.write(json.dumps({                                        # Invalid job type
+            "id": "bad_job_type",
+            "job_type": "NONEXISTENT_TYPE",
+            "params": {},
+            "data": {},
+            "provider_name": "test",
+            "device_name": "device",
+            "dispatch_time": "2024-01-01T00:00:00"
+        }) + "\n")
+        f.write(json.dumps({                                        # Bad datetime
+            "id": "bad_datetime",
+            "job_type": FAKE_BENCHMARK_NAME,
+            "params": {},
+            "data": {},
+            "provider_name": "test",
+            "device_name": "device",
+            "dispatch_time": "not-a-datetime"
+        }) + "\n")
+        f.write(valid_job_2.serialize() + "\n")                     # Valid
+
     caplog.set_level(logging.WARNING)
-    new_job_manager = JobManager()
-    jobs = new_job_manager.get_jobs()
-    assert len(jobs) == 1
-    assert jobs[0].id == sample_job.id
-    assert "invalid" in caplog.text
+    manager = JobManager()
+    loaded_jobs = manager.get_jobs()
+
+    # Expect only 2 valid jobs to be loaded
+    assert len(loaded_jobs) == 2
+    assert loaded_jobs[0].id == "valid_job_1"
+    assert loaded_jobs[1].id == "valid_job_2"
+
+    # Expect 4 warning logs for invalid entries (excluding blank line)
+    warnings = [rec.message for rec in caplog.records if rec.levelno == logging.WARNING]
+    assert len(warnings) == 4
+
+    # Verify log contents by error type
+    joined_logs = " ".join(warnings)
+    assert "Invalid JSON at position" in joined_logs
+    assert (
+        "Missing required field" in joined_logs or
+        "Incorrect data structure" in joined_logs or
+        "Data structure mismatch" in joined_logs
+    )
+    assert "Unknown job type:" in joined_logs
+    assert "Invalid datetime format:" in joined_logs or "Bad datetime format:" in joined_logs
+
+
+
+def test_load_jobs_with_only_invalid_entries(tmpdir, caplog):
+    """Test that a warning is logged when no valid jobs are found."""
+    jobs_file = tmpdir.join("test_jobs_only_invalid.jsonl")
+    JobManager.jobs_file = str(jobs_file)
+
+    with open(jobs_file, "w") as f:
+        f.write('{"bad": "entry", "no_required_fields": true}\n')  # Invalid entry
+
+    caplog.set_level(logging.WARNING)
+    job_manager = JobManager()
+    jobs = job_manager.get_jobs()
+
+    assert jobs == []  # No valid jobs
+    warning_messages = [record.message for record in caplog.records]
+    assert any("No valid jobs found" in msg for msg in warning_messages)
+
+
+def test_load_jobs_file_missing(tmpdir):
+    """Test that no errors occur and jobs list is empty when jobs file is missing."""
+    missing_file_path = tmpdir.join("non_existent.jsonl")
+    JobManager.jobs_file = str(missing_file_path)
+
+    job_manager = JobManager()
+    assert job_manager.get_jobs() == []


### PR DESCRIPTION
# Description

This PR addresses Issue [#301](https://github.com/unitaryfoundation/metriq-gym/issues/301) by improving the robustness of the `JobManager` when handling invalid entries in the input `.jsonl` file. Previously, such entries could lead to unhandled exceptions. This change ensures that invalid or malformed job entries are caught gracefully, preventing the entire job dispatch process from failing.

# Issue ticket number and link

Fixes [#301](https://github.com/unitaryfoundation/metriq-gym/issues/301)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A test case has been added that includes a deliberately invalid JSONL entry to ensure the `JobManager` continues running without crashing. The behavior was verified locally, and the invalid entry is now skipped with a warning.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
