### PR TITLE
JobManager more lenient on invalid jobs in jsonl file #301

### DIFF
--- a/metriq_gym/benchmarks/quantum_volume.py
+++ b/metriq_gym/benchmarks/quantum_volume.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 from qbraid import GateModelResultData, QuantumDevice, QuantumJob
 from qbraid.runtime.result_data import MeasCount
-from pyqrack import QrackSimulator
 from qiskit import QuantumCircuit
 
 from metriq_gym.circuits import qiskit_random_circuit_sampling
@@ -35,6 +34,16 @@ class QuantumVolumeResult(BenchmarkResult):
 
 
 def prepare_qv_circuits(n: int, num_trials: int) -> tuple[list[QuantumCircuit], list[list[float]]]:
+    # Lazy import of pyqrack to avoid system dependency issues
+    try:
+        from pyqrack import QrackSimulator
+    except ImportError as e:
+        raise ImportError(
+            "pyqrack is required for Quantum Volume benchmarks. "
+            "Please ensure Qrack and its dependencies (OpenCL) are properly installed. "
+            f"Original error: {e}"
+        ) from e
+    
     circuits = []
     ideal_probs = []
 

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -143,8 +143,8 @@ def test_load_jobs_with_invalid_entries(tmpdir, caplog):
     
     # Check that warning messages contain expected information and specific error types
     warning_text = " ".join(warning_messages)
-    assert "malformed JSON" in warning_text           # JSONDecodeError
-    assert "Incorrect data structure" in warning_text # TypeError from constructor 
-    assert "Unknown job type" in warning_text         # ValueError from invalid enum
-    assert "Invalid datetime format" in warning_text  # ValueError from datetime parsing
+    assert "Malformed JSON at pos" in warning_text        # JSONDecodeError
+    assert "Incorrect data structure:" in warning_text    # TypeError from constructor 
+    assert "Unknown job type:" in warning_text            # ValueError from invalid enum
+    assert "Bad datetime format:" in warning_text         # ValueError from datetime parsing
     assert all(str(jobs_file) in msg for msg in warning_messages)

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from unittest.mock import patch
 import pytest
 from datetime import datetime
@@ -48,3 +50,86 @@ def test_load_jobs_with_existing_data(job_manager, sample_job):
     jobs = new_job_manager.get_jobs()
     assert len(jobs) == 1
     assert jobs[0].id == sample_job.id
+
+
+def test_load_jobs_with_invalid_entries(tmpdir, caplog):
+    """Test that JobManager gracefully handles invalid job entries in the JSONL file."""
+    jobs_file = tmpdir.join("test_jobs_with_invalid.jsonl")
+    JobManager.jobs_file = str(jobs_file)
+    
+    # Create a valid job
+    valid_job = MetriqGymJob(
+        id="valid_job_id",
+        provider_name="test_provider",
+        device_name="test_device",
+        job_type=FakeJobType(FAKE_BENCHMARK_NAME),
+        params={},
+        data={},
+        dispatch_time=datetime.now(),
+    )
+    
+    # Write a mix of valid and invalid job entries to the file
+    with open(jobs_file, "w") as f:
+        # Valid job
+        f.write(valid_job.serialize() + "\n")
+        
+        # Invalid JSON (malformed)
+        f.write('{"invalid": "json", "missing_fields": true\n')
+        
+        # Valid JSON but invalid job type
+        invalid_job_data = {
+            "id": "invalid_job_type_id",
+            "job_type": "NONEXISTENT_TYPE",
+            "params": {},
+            "data": {},
+            "provider_name": "test_provider",
+            "device_name": "test_device",
+            "dispatch_time": "2023-01-01T00:00:00"
+        }
+        f.write(json.dumps(invalid_job_data) + "\n")
+        
+        # Valid JSON but invalid datetime format
+        invalid_datetime_job = {
+            "id": "invalid_datetime_id",
+            "job_type": FAKE_BENCHMARK_NAME,
+            "params": {},
+            "data": {},
+            "provider_name": "test_provider",
+            "device_name": "test_device",
+            "dispatch_time": "invalid-datetime-format"
+        }
+        f.write(json.dumps(invalid_datetime_job) + "\n")
+        
+        # Another valid job
+        valid_job2 = MetriqGymJob(
+            id="valid_job_id_2",
+            provider_name="test_provider_2",
+            device_name="test_device_2",
+            job_type=FakeJobType(FAKE_BENCHMARK_NAME),
+            params={},
+            data={},
+            dispatch_time=datetime.now(),
+        )
+        f.write(valid_job2.serialize() + "\n")
+    
+    # Set up logging capture
+    caplog.set_level(logging.WARNING)
+    
+    # Load jobs and verify behavior
+    job_manager = JobManager()
+    jobs = job_manager.get_jobs()
+    
+    # Should load only the 2 valid jobs
+    assert len(jobs) == 2
+    assert jobs[0].id == "valid_job_id"
+    assert jobs[1].id == "valid_job_id_2"
+    
+    # Should have logged warnings for the 3 invalid entries
+    warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warning_messages) == 3
+    
+    # Check that warning messages contain expected information
+    assert any("line 2" in msg for msg in warning_messages)
+    assert any("line 3" in msg for msg in warning_messages) 
+    assert any("line 4" in msg for msg in warning_messages)
+    assert all(str(jobs_file) in msg for msg in warning_messages)


### PR DESCRIPTION
# Description
Enhanced JobManager to gracefully handle invalid job entries in the local JSONL database file. Previously, any invalid entry would prevent loading of all jobs. Now the system loads all valid jobs and logs warnings for invalid ones, preventing failures due to schema changes or data corruption.
Additionally fixed a blocking issue where pyqrack import was preventing tests from running by implementing lazy import in quantum_volume.py.

# Issue ticket number and link
Fixes #301

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added comprehensive test `test_load_jobs_with_invalid_entries()` that creates a JSONL file with mixed valid and invalid entries
- Test verifies that only valid jobs are loaded (2 out of 5 entries)
- Confirms that appropriate warning messages are logged for invalid entries
- All existing tests continue to pass
- Verified that tests now run without requiring pyqrack system dependencies

Run tests with:
```bash
poetry run pytest tests/test_job_manager.py::test_load_jobs_with_invalid_entries -v
poetry run pytest tests/test_job_manager.py -v
```
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)