### PR TITLE
feat: make JobManager more lenient with invalid JSONL entries[UNITARY HACK]

### DIFF
--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -73,28 +73,31 @@ class JobManager:
                         continue
                     try:
                         # First try to parse JSON
-                        job_dict = json.loads(stripped_line)
+                        try:
+                            job_dict = json.loads(stripped_line)
+                        except json.JSONDecodeError as e:
+                            logger.warning(f"Line {line_number}: Invalid JSON (pos {e.pos})")
+                            continue
                         
                         # Then try to create job object
-                        job = MetriqGymJob(**job_dict)
-                        job.job_type = JobType(job_dict["job_type"])
-                        job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
-                        
-                        # Validate required fields
-                        if not isinstance(job.job_type, JobType):
-                            raise ValueError("Invalid or missing job_type")
+                        try:
+                            job = MetriqGymJob(**job_dict)
+                            job.job_type = JobType(job_dict["job_type"])
+                            job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
                             
-                        if not isinstance(job.params, dict):
-                            raise TypeError("Invalid or missing params")
-                            
-                        if not isinstance(job.device_name, str):
-                            raise ValueError("Invalid or missing device_name")
-                            
-                        self.jobs.append(job)
-                    except json.JSONDecodeError as e:
-                        logger.warning(f"Line {line_number}: Invalid JSON (pos {e.pos})")
-                    except (KeyError, TypeError, ValueError) as e:
-                        logger.warning(f"Line {line_number}: {e}")
+                            # Validate required fields
+                            if not isinstance(job.job_type, JobType):
+                                raise ValueError("Invalid or missing job_type")
+                                
+                            if not isinstance(job.params, dict):
+                                raise TypeError("Invalid or missing params")
+                                
+                            if not isinstance(job.device_name, str):
+                                raise ValueError("Invalid or missing device_name")
+                                
+                            self.jobs.append(job)
+                        except (KeyError, TypeError, ValueError) as e:
+                            logger.warning(f"Line {line_number}: {e}")
                     except Exception as e:
                         logger.warning(f"Line {line_number}: Unexpected error ({type(e).__name__}) - {e}")
 

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -72,16 +72,22 @@ class JobManager:
                     if not stripped_line:
                         continue
                     try:
-                        job = MetriqGymJob.deserialize(stripped_line)
+                        # First try to parse JSON
+                        job_dict = json.loads(stripped_line)
+                        
+                        # Then try to create job object
+                        job = MetriqGymJob(**job_dict)
+                        job.job_type = JobType(job_dict["job_type"])
+                        job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
                         
                         # Validate required fields
-                        if not isinstance(getattr(job, "job_type", None), JobType):
+                        if not isinstance(job.job_type, JobType):
                             raise ValueError("Invalid or missing job_type")
                             
-                        if not isinstance(getattr(job, "params", None), dict):
+                        if not isinstance(job.params, dict):
                             raise TypeError("Invalid or missing params")
                             
-                        if not isinstance(getattr(job, "device_name", None), str):
+                        if not isinstance(job.device_name, str):
                             raise ValueError("Invalid or missing device_name")
                             
                         self.jobs.append(job)

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 import pytest
+import logging
 from datetime import datetime
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from tests.test_schema_validator import FAKE_BENCHMARK_NAME, FakeJobType
@@ -31,8 +32,11 @@ def sample_job():
     )
 
 
-def test_load_jobs_empty_file(job_manager):
+def test_load_jobs_empty_file(job_manager, caplog):
+    """Test handling of empty file."""
+    caplog.set_level(logging.WARNING)
     assert job_manager.get_jobs() == []
+    assert "No valid jobs found" in caplog.text
 
 
 def test_add_job(job_manager, sample_job):
@@ -48,3 +52,43 @@ def test_load_jobs_with_existing_data(job_manager, sample_job):
     jobs = new_job_manager.get_jobs()
     assert len(jobs) == 1
     assert jobs[0].id == sample_job.id
+
+
+def test_load_jobs_skips_invalid(job_manager, sample_job, caplog):
+    """Test that invalid JSONL entries are skipped with appropriate warnings."""
+    # Add a valid job
+    job_manager.add_job(sample_job)
+    
+    # Add various invalid entries
+    with open(JobManager.jobs_file, "a") as f:
+        f.write('{"id": "invalid"}\n')  # Missing required fields
+        f.write('{"invalid": "json"}\n')  # Invalid JSON
+        f.write('{"id": "test", "job_type": "invalid", "params": {}, "device_name": "test"}\n')  # Invalid job_type
+        f.write('{"id": "test", "job_type": "BSEQ", "params": "not_dict", "device_name": "test"}\n')  # Invalid params
+        f.write('{"id": "test", "job_type": "BSEQ", "params": {}, "device_name": 123}\n')  # Invalid device_name
+    
+    caplog.set_level(logging.WARNING)
+    new_job_manager = JobManager()
+    
+    # Verify only valid job was loaded
+    jobs = new_job_manager.get_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].id == sample_job.id
+    
+    # Verify warnings were logged
+    log_text = caplog.text
+    assert "Invalid JSON" in log_text
+    assert "Invalid or missing job_type" in log_text
+    assert "Invalid or missing params" in log_text
+    assert "Invalid or missing device_name" in log_text
+
+
+def test_load_jobs_whitespace_only(job_manager, caplog):
+    """Test handling of file with only whitespace."""
+    with open(JobManager.jobs_file, "w") as f:
+        f.write("\n\n  \n\t\n")
+    
+    caplog.set_level(logging.WARNING)
+    new_job_manager = JobManager()
+    assert new_job_manager.get_jobs() == []
+    assert "No valid jobs found" in caplog.text

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -35,8 +35,9 @@ def sample_job():
 def test_load_jobs_empty_file(job_manager, caplog):
     """Test handling of empty file."""
     caplog.set_level(logging.WARNING)
-    assert job_manager.get_jobs() == []
-    assert "No valid jobs found" in caplog.text
+    with caplog.at_level(logging.WARNING):
+        assert job_manager.get_jobs() == []
+        assert "No valid jobs found" in caplog.text
 
 
 def test_add_job(job_manager, sample_job):
@@ -67,20 +68,20 @@ def test_load_jobs_skips_invalid(job_manager, sample_job, caplog):
         f.write('{"id": "test", "job_type": "BSEQ", "params": "not_dict", "device_name": "test"}\n')  # Invalid params
         f.write('{"id": "test", "job_type": "BSEQ", "params": {}, "device_name": 123}\n')  # Invalid device_name
     
-    caplog.set_level(logging.WARNING)
-    new_job_manager = JobManager()
-    
-    # Verify only valid job was loaded
-    jobs = new_job_manager.get_jobs()
-    assert len(jobs) == 1
-    assert jobs[0].id == sample_job.id
-    
-    # Verify warnings were logged
-    log_text = caplog.text
-    assert "Invalid JSON" in log_text
-    assert "Invalid or missing job_type" in log_text
-    assert "Invalid or missing params" in log_text
-    assert "Invalid or missing device_name" in log_text
+    with caplog.at_level(logging.WARNING):
+        new_job_manager = JobManager()
+        
+        # Verify only valid job was loaded
+        jobs = new_job_manager.get_jobs()
+        assert len(jobs) == 1
+        assert jobs[0].id == sample_job.id
+        
+        # Verify warnings were logged
+        log_text = caplog.text
+        assert "Invalid JSON" in log_text
+        assert "Invalid or missing job_type" in log_text
+        assert "Invalid or missing params" in log_text
+        assert "Invalid or missing device_name" in log_text
 
 
 def test_load_jobs_whitespace_only(job_manager, caplog):
@@ -88,7 +89,7 @@ def test_load_jobs_whitespace_only(job_manager, caplog):
     with open(JobManager.jobs_file, "w") as f:
         f.write("\n\n  \n\t\n")
     
-    caplog.set_level(logging.WARNING)
-    new_job_manager = JobManager()
-    assert new_job_manager.get_jobs() == []
-    assert "No valid jobs found" in caplog.text
+    with caplog.at_level(logging.WARNING):
+        new_job_manager = JobManager()
+        assert new_job_manager.get_jobs() == []
+        assert "No valid jobs found" in caplog.text


### PR DESCRIPTION
**Fixes #301**

This PR improves JobManager's handling of invalid JSONL entries in the local jobs file. Instead of failing completely on invalid entries, it now:
- Skips invalid entries with appropriate warnings
- Validates required fields (job_type, params, device_name)
- Continues loading valid entries
- Provides detailed error messages for debugging

**Changes:**
- Add logging for different types of errors
- Add field validation before job loading
- Add test coverage for invalid entries
- Add warning when no valid jobs found

Solved under UNITARY HACK BOUNTY
