### PR TITLE
feat: enhance job status reporting with provider-specific details

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,13 @@ INFO - Polling job...
 BSEQResult(largest_connected_size=100, fraction_connected=0.7874015748031497)
 ```
 
-In the event where the job has not completed, we would receive the following message instead
+In the event where the job has not completed, we would receive the following message:
 
 ```sh
 INFO - Polling job...
-INFO - Job is not yet completed. Please try again later.
+INFO - Job is not yet completed. Current status:
+INFO - - d0wtyfhvx7bg008203b0: QUEUED (position 3)
+INFO - Please try again later.
 ```
 
 As a convenience, while we could supply the metriq-gym job ID, we can also poll the job by running `mgym poll` and then selecting the job to poll by index from our local metriq-gym jobs database.
@@ -187,7 +189,7 @@ INFO - Polling job...
 First, follow the [Setup](#setup) instructions above.
 
 ### Updating the submodule
-To pull the latest changes from the submodule’s repository:
+To pull the latest changes from the submodule's repository:
 
 ```sh
 cd submodules/qiskit-device-benchmarking

--- a/metriq_gym/qplatform/__init__.py
+++ b/metriq_gym/qplatform/__init__.py
@@ -6,6 +6,8 @@ access to metadata and introspection utilities for quantum computing platforms.
 
 It defines generic functions (using singledispatch) to fetch various metadata or
 properties, such as backend versions, coupling graphs, provider details, and job metadata.
+Job metadata includes execution time and provider-specific status information such
+as queue position when available.
 
 It builds on top of qBraid's runtime module, and in the future,
 functions defined here may be upstreamed to qBraid's runtime module.
@@ -13,6 +15,7 @@ functions defined here may be upstreamed to qBraid's runtime module.
 Submodules:
 - device:    introspection functions related to quantum devices,
               such as coupling graphs, backend versions, and calibration data.
-- job: standardized queries for job execution details and metadata (e.g. wall-clock execution time).
+- job: standardized queries for job execution details and metadata (e.g. wall-clock execution time,
+       queue position, and status information).
 - provider: functions to introspect provider-specific metadata or capabilities.
 """

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -1,8 +1,161 @@
+from dataclasses import dataclass
+from enum import StrEnum
 from functools import singledispatch
+from typing import Optional, Any
 
 from qbraid import QuantumJob
 from qbraid.runtime import QiskitJob, AzureQuantumJob, BraketQuantumTask
+from qbraid.runtime.enums import JobStatus as QbraidJobStatus
 from qiskit_ibm_runtime.execution_span import ExecutionSpans
+
+
+class JobStatus(StrEnum):
+    """Provider-agnostic job status enum.
+    
+    This enum extends qBraid's JobStatus with additional statuses and
+    provides a consistent interface across different providers.
+    """
+    INITIALIZING = "INITIALIZING"
+    QUEUED = "QUEUED"
+    VALIDATING = "VALIDATING"
+    RUNNING = "RUNNING"
+    CANCELLING = "CANCELLING"
+    CANCELLED = "CANCELLED"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    UNKNOWN = "UNKNOWN"
+    HOLD = "HOLD"
+
+    @classmethod
+    def from_qbraid(cls, status: QbraidJobStatus) -> "JobStatus":
+        """Convert qBraid JobStatus to metriq-gym JobStatus."""
+        return cls(status.name)
+
+    @classmethod
+    def terminal_states(cls) -> set["JobStatus"]:
+        """Returns the final job statuses."""
+        return {cls.COMPLETED, cls.CANCELLED, cls.FAILED}
+
+
+@dataclass
+class JobStatusInfo:
+    """Provider-agnostic job status information.
+    
+    This class provides a consistent interface for job status information
+    across different quantum computing providers.
+    
+    Attributes:
+        status: The current status of the job
+        queue_position: Optional queue position if available from provider
+        queue_type: Optional queue type (e.g. "NORMAL", "PRIORITY") if available
+        message: Optional status message or error details
+    """
+    status: JobStatus
+    queue_position: Optional[int] = None
+    queue_type: Optional[str] = None
+    message: Optional[str] = None
+
+    def __str__(self) -> str:
+        """String representation of job status info."""
+        msg = f"{self.status.value}"
+        if self.queue_position is not None:
+            msg += f" (position {self.queue_position}"
+            if self.queue_type:
+                msg += f", {self.queue_type}"
+            msg += ")"
+        if self.message:
+            msg += f": {self.message}"
+        return msg
+
+
+def extract_status_info(quantum_job: QuantumJob) -> JobStatusInfo:
+    """Extract job status information from a quantum job.
+    
+    This is a helper function that handles the common case of extracting
+    status information from a quantum job. It uses the provider-specific
+    implementations where available.
+    
+    Args:
+        quantum_job: The quantum job to extract status from
+        
+    Returns:
+        JobStatusInfo containing the extracted status information
+    """
+    try:
+        status = JobStatus.from_qbraid(quantum_job.status())
+    except Exception:
+        status = JobStatus.UNKNOWN
+
+    queue_position = None
+    queue_type = None
+    message = None
+
+    # Try to get queue position if available
+    if hasattr(quantum_job, "queue_position"):
+        try:
+            queue_info = quantum_job.queue_position()
+            if isinstance(queue_info, (int, str)):
+                queue_position = int(queue_info)
+            elif hasattr(queue_info, "position"):
+                queue_position = queue_info.position
+            if hasattr(queue_info, "queue_type"):
+                queue_type = queue_info.queue_type
+            if hasattr(queue_info, "message"):
+                message = queue_info.message
+        except Exception:
+            pass
+
+    return JobStatusInfo(
+        status=status,
+        queue_position=queue_position,
+        queue_type=queue_type,
+        message=message
+    )
+
+
+@singledispatch
+def job_status(quantum_job: QuantumJob) -> JobStatusInfo:
+    """Get status information for a quantum job.
+    
+    This is the default implementation that works for any QuantumJob.
+    Provider-specific implementations can be registered for better handling.
+    
+    Args:
+        quantum_job: The quantum job to get status for
+        
+    Returns:
+        JobStatusInfo containing the job's status information
+    """
+    return extract_status_info(quantum_job)
+
+
+@job_status.register
+def _(quantum_job: QiskitJob) -> JobStatusInfo:
+    """Get status information for an IBM Qiskit job.
+    
+    IBM jobs provide queue position information through the queue_position()
+    method. The position is within the scope of the provider.
+    """
+    return extract_status_info(quantum_job)
+
+
+@job_status.register
+def _(quantum_job: BraketQuantumTask) -> JobStatusInfo:
+    """Get status information for an AWS Braket quantum task.
+    
+    AWS Braket tasks provide queue position and type information through
+    the queue_position() method. The queue type can be "NORMAL" or "PRIORITY".
+    """
+    return extract_status_info(quantum_job)
+
+
+@job_status.register
+def _(quantum_job: AzureQuantumJob) -> JobStatusInfo:
+    """Get status information for an Azure Quantum job.
+    
+    Azure Quantum jobs currently don't provide queue position information.
+    """
+    return extract_status_info(quantum_job)
 
 
 @singledispatch

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import singledispatch
-from typing import Optional, Any
+from typing import Optional
 
 from qbraid import QuantumJob
 from qbraid.runtime import QiskitJob, AzureQuantumJob, BraketQuantumTask

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -114,7 +114,11 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         else:
             CliExporter(metriq_job, results).export()
     else:
-        print("Job is not yet completed. Please try again later.")
+        print("Job is not yet completed. Current status:")
+        for task in quantum_jobs:
+            info = job_status(task)
+            print(f"- {task.id}: {info}")
+        print("Please try again later.")
 
 
 def view_job(args: argparse.Namespace, job_manager: JobManager) -> None:

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -26,6 +26,7 @@ from metriq_gym.exporters.json_exporter import JsonExporter
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.schema_validator import load_and_validate, validate_and_create_model
 from metriq_gym.benchmarks import JobType
+from metriq_gym.qplatform.job import job_status
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("metriq_gym")

--- a/tests/qplatform/test_job.py
+++ b/tests/qplatform/test_job.py
@@ -3,7 +3,6 @@ import pytest
 from qbraid.runtime import QuantumJob, QiskitJob, BraketQuantumTask
 from metriq_gym.qplatform.job import execution_time, job_status, JobStatusInfo, JobStatus
 from datetime import datetime, timedelta
-from qbraid.runtime.enums import JobStatus as QbraidJobStatus
 
 
 def test_execution_time_qiskit():

--- a/tests/qplatform/test_job.py
+++ b/tests/qplatform/test_job.py
@@ -1,8 +1,9 @@
 from unittest.mock import MagicMock
 import pytest
-from qbraid.runtime import QuantumJob, QiskitJob
-from metriq_gym.qplatform.job import execution_time
+from qbraid.runtime import QuantumJob, QiskitJob, BraketQuantumTask
+from metriq_gym.qplatform.job import execution_time, job_status, JobStatusInfo, JobStatus
 from datetime import datetime, timedelta
+from qbraid.runtime.enums import JobStatus as QbraidJobStatus
 
 
 def test_execution_time_qiskit():
@@ -17,6 +18,118 @@ def test_execution_time_qiskit():
 
 
 def test_execution_time_unsupported():
-    mock_job = MagicMock(spec=QuantumJob)
+    """Verify execution_time raises NotImplementedError."""
+    quantum_job = MagicMock(spec=QuantumJob)
     with pytest.raises(NotImplementedError):
-        execution_time(mock_job)
+        execution_time(quantum_job)
+
+
+def test_job_status_with_queue_position():
+    """Verify status and queue position are extracted correctly from QiskitJob."""
+    status_obj = MagicMock()
+    status_obj.name = "QUEUED"
+
+    qiskit_job = MagicMock(spec=QiskitJob)
+    qiskit_job.status.return_value = status_obj
+    qiskit_job.queue_position.return_value = 3
+
+    info = job_status(qiskit_job)
+
+    assert isinstance(info, JobStatusInfo)
+    assert info.status == JobStatus.QUEUED
+    assert info.queue_position == 3
+    assert info.queue_type is None
+    assert info.message is None
+
+
+def test_job_status_with_queue_type():
+    """Verify status and queue type are extracted correctly from BraketQuantumTask."""
+    status_obj = MagicMock()
+    status_obj.name = "QUEUED"
+
+    queue_info = MagicMock()
+    queue_info.position = 5
+    queue_info.queue_type = "PRIORITY"
+    queue_info.message = "High priority task"
+
+    braket_job = MagicMock(spec=BraketQuantumTask)
+    braket_job.status.return_value = status_obj
+    braket_job.queue_position.return_value = queue_info
+
+    info = job_status(braket_job)
+
+    assert isinstance(info, JobStatusInfo)
+    assert info.status == JobStatus.QUEUED
+    assert info.queue_position == 5
+    assert info.queue_type == "PRIORITY"
+    assert info.message == "High priority task"
+
+
+def test_job_status_without_queue_position():
+    """Verify fallback when queue position is unavailable."""
+    status_obj = MagicMock()
+    status_obj.name = "RUNNING"
+
+    quantum_job = MagicMock(spec=QuantumJob)
+    quantum_job.status.return_value = status_obj
+    quantum_job.queue_position = MagicMock()
+    quantum_job.queue_position.side_effect = Exception("Queue position not available")
+
+    info = job_status(quantum_job)
+
+    assert isinstance(info, JobStatusInfo)
+    assert info.status == JobStatus.RUNNING
+    assert info.queue_position is None
+    assert info.queue_type is None
+    assert info.message is None
+
+
+def test_job_status_unknown():
+    """Verify handling of unknown status."""
+    quantum_job = MagicMock(spec=QuantumJob)
+    quantum_job.status.side_effect = Exception("Status error")
+    # Explicitly set queue_position to None to prevent auto-creation of nested mocks
+    quantum_job.queue_position = None
+
+    info = job_status(quantum_job)
+
+    assert isinstance(info, JobStatusInfo)
+    assert info.status == JobStatus.UNKNOWN
+    assert info.queue_position is None
+    assert info.queue_type is None
+    assert info.message is None
+
+
+def test_job_status_string_representation():
+    """Verify string representation of JobStatusInfo."""
+    # Basic status
+    info = JobStatusInfo(status=JobStatus.RUNNING)
+    assert str(info) == "RUNNING"
+
+    # With queue position
+    info = JobStatusInfo(status=JobStatus.QUEUED, queue_position=3)
+    assert str(info) == "QUEUED (position 3)"
+
+    # With queue type
+    info = JobStatusInfo(
+        status=JobStatus.QUEUED,
+        queue_position=3,
+        queue_type="PRIORITY"
+    )
+    assert str(info) == "QUEUED (position 3, PRIORITY)"
+
+    # With message
+    info = JobStatusInfo(
+        status=JobStatus.FAILED,
+        message="Circuit too large"
+    )
+    assert str(info) == "FAILED: Circuit too large"
+
+    # Complete info
+    info = JobStatusInfo(
+        status=JobStatus.QUEUED,
+        queue_position=3,
+        queue_type="PRIORITY",
+        message="High priority task"
+    )
+    assert str(info) == "QUEUED (position 3, PRIORITY): High priority task"


### PR DESCRIPTION
## Description
This PR enhances job status reporting to provide more detailed information from quantum computing providers, addressing issue #238. The implementation is designed to be cross-platform and gracefully handles cases where certain metadata may not be available from specific providers.

## Changes
1. Added `JobStatus` enum:
   - Provider-agnostic status representation
   - Includes all common statuses (INITIALIZING, QUEUED, RUNNING, etc.)
   - Converts provider-specific statuses to standardized format

2. Added `JobStatusInfo` dataclass:
   - Status: Current job status
   - Queue position: Position in provider's queue (when available)
   - Queue type: Type of queue (e.g., "NORMAL", "PRIORITY")
   - Message: Additional status information or error details

3. Implemented provider-specific handlers:
   - IBM: Queue position from QiskitJob
   - AWS: Queue position and type from BraketQuantumTask
   - Azure: Basic status information (queue info not available)
   - Default handler for other providers

4. Updated CLI output:
   - Replaced generic "Job is not yet completed" message
   - Now shows detailed status information including:
     - Current status
     - Queue position (if available)
     - Queue type (if available)
     - Error messages (if any)
