### PR TITLE
Auto squash and merge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After switching to ruleset-based branch protection (defined in https://github.com/unitaryfoundation/metriq-gym/settings/rules), merge commits are not allowed on this repository. This causes an error with the current dependabot automerge workflow, see https://github.com/unitaryfoundation/metriq-gym/pull/395

Easy fix in this PR :)