### PR TITLE
Package submodules too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# poetry-build
+dist/
+
 # Unit test / coverage reports
 .tox/
 .nox/

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ poetry install
 ```
 from the root folder of the project, in order to install the project dependencies. 
 
-Because the `qiskit-device-benchmarking` submodule cannot be listed as a publishable dependency, it must be installed
-into the environment manually after the main installation.
-
-```sh
-poetry run pip install -e submodules/qiskit-device-benchmarking
-```
-
 We recommend doing this in an isolated virtual environment. See [Poetry
 documentation](https://python-poetry.org/docs/managing-environments/) for more information on managing virtual
 environments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,21 @@ maintainers = [
     { name = "Vincent Russo", email = "vincent@unitary.foundation"},
 ]
 readme = "README.md"
+license = { text = "Apache-2.0" }
 version = "0.1.1"
 requires-python = ">=3.12"
 
 [project.scripts]
 mgym = "metriq_gym.run:main"
+
+[tool.poetry]
+packages = [
+    { include = "metriq_gym", from = "." },
+    { include = "qiskit_device_benchmarking", from = "submodules/qiskit-device-benchmarking" }
+]
+include = [
+    { path = "submodules/qiskit-device-benchmarking/LICENSE", format = ["sdist", "wheel"] }
+]
 
 [tool.poetry.dependencies]
 jsonschema = "^4.23.0"


### PR DESCRIPTION
# Description
Running `mgym` from the metriq-gym v0.1.1 package installed by pip in a fresh environment, raises this error:
```
Traceback (most recent call last):
  File "/opt/miniconda3/envs/scratch/bin/mgym", line 5, in <module>
    from metriq_gym.run import main
  File "/opt/miniconda3/envs/scratch/lib/python3.13/site-packages/metriq_gym/run.py", line 21, in <module>
    from metriq_gym.benchmarks import (
    ...<3 lines>...
    )
  File "/opt/miniconda3/envs/scratch/lib/python3.13/site-packages/metriq_gym/benchmarks/__init__.py", line 5, in <module>
    from metriq_gym.benchmarks.clops import Clops, ClopsData
  File "/opt/miniconda3/envs/scratch/lib/python3.13/site-packages/metriq_gym/benchmarks/clops.py", line 8, in <module>
    from qiskit_device_benchmarking.clops.clops_benchmark import append_1q_layer
ModuleNotFoundError: No module named 'qiskit_device_benchmarking'
```

# Solution
Add the submodule (and their license file) as a package in poetry

# Testing
Tested with 
```
poetry build
```
and then `pip install` the wheel generated by the build in a fresh environment.  


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
