### PR TITLE
Hide details of provider ids flattening in framework

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,4 +1,5 @@
 import argparse
+from collections.abc import Iterable
 
 from pydantic import BaseModel
 from dataclasses import dataclass
@@ -6,11 +7,24 @@ from dataclasses import dataclass
 from qbraid import GateModelResultData, QuantumDevice, QuantumJob
 
 
+def flatten_job_ids(quantum_job: QuantumJob | Iterable[QuantumJob]) -> list[str]:
+    if isinstance(quantum_job, QuantumJob):
+        return [quantum_job.id]
+    elif isinstance(quantum_job, Iterable):
+        return [job.id for job in quantum_job]
+    else:
+        raise TypeError(f"Unsupported job type: {type(quantum_job)}")
+
+
 @dataclass
 class BenchmarkData:
     """Stores intermediate data from pre-processing and dispatching"""
 
     provider_job_ids: list[str]
+
+    @classmethod
+    def from_quantum_job(cls, quantum_job, **kwargs):
+        return cls(provider_job_ids=flatten_job_ids(quantum_job), **kwargs)
 
 
 class BenchmarkResult(BaseModel):

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,5 +1,5 @@
 import argparse
-from collections.abc import Iterable
+from typing import Iterable
 
 from pydantic import BaseModel
 from dataclasses import dataclass
@@ -12,8 +12,7 @@ def flatten_job_ids(quantum_job: QuantumJob | Iterable[QuantumJob]) -> list[str]
         return [quantum_job.id]
     elif isinstance(quantum_job, Iterable):
         return [job.id for job in quantum_job]
-    else:
-        raise TypeError(f"Unsupported job type: {type(quantum_job)}")
+    raise TypeError(f"Unsupported job type: {type(quantum_job)}")
 
 
 @dataclass
@@ -23,7 +22,8 @@ class BenchmarkData:
     provider_job_ids: list[str]
 
     @classmethod
-    def from_quantum_job(cls, quantum_job, **kwargs):
+    def from_quantum_job(cls, quantum_job, **kwargs) -> "BenchmarkData":
+        """Populate the provider job IDs from a QuantumJob or iterable of QuantumJobs."""
         return cls(provider_job_ids=flatten_job_ids(quantum_job), **kwargs)
 
 

--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -22,7 +22,7 @@ class BenchmarkData:
     provider_job_ids: list[str]
 
     @classmethod
-    def from_quantum_job(cls, quantum_job, **kwargs) -> "BenchmarkData":
+    def from_quantum_job(cls, quantum_job, **kwargs):
         """Populate the provider job IDs from a QuantumJob or iterable of QuantumJobs."""
         return cls(provider_job_ids=flatten_job_ids(quantum_job), **kwargs)
 

--- a/metriq_gym/benchmarks/clops.py
+++ b/metriq_gym/benchmarks/clops.py
@@ -9,7 +9,6 @@ from qiskit_device_benchmarking.clops.clops_benchmark import append_1q_layer
 
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
 from metriq_gym.qplatform.job import execution_time
-from metriq_gym.helpers.task_helpers import flatten_job_ids
 from metriq_gym.qplatform.device import connectivity_graph
 
 
@@ -144,9 +143,7 @@ class Clops(Benchmark):
             topology_graph=topology_graph,
             total_qubits=num_qubits,
         )
-        quantum_job: QuantumJob | list[QuantumJob] = device.run(circuits, shots=self.params.shots)
-        provider_job_ids = flatten_job_ids(quantum_job)
-        return ClopsData(provider_job_ids=provider_job_ids)
+        return ClopsData.from_quantum_job(device.run(circuits, shots=self.params.shots))
 
     def poll_handler(
         self,

--- a/metriq_gym/benchmarks/qml_kernel.py
+++ b/metriq_gym/benchmarks/qml_kernel.py
@@ -9,7 +9,7 @@ from qbraid import GateModelResultData, QuantumDevice, QuantumJob
 from qbraid.runtime.result_data import MeasCount
 
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
-from metriq_gym.helpers.task_helpers import flatten_counts, flatten_job_ids
+from metriq_gym.helpers.task_helpers import flatten_counts
 
 
 @dataclass
@@ -74,11 +74,10 @@ def calculate_accuracy_score(num_qubits: int, count_results: MeasCount) -> float
 
 class QMLKernel(Benchmark):
     def dispatch_handler(self, device: QuantumDevice) -> QMLKernelData:
-        qc = create_inner_product_circuit(self.params.num_qubits)
-        quantum_job: QuantumJob | list[QuantumJob] = device.run(qc, shots=self.params.shots)
-        provider_job_ids = flatten_job_ids(quantum_job)
-        return QMLKernelData(
-            provider_job_ids=provider_job_ids,
+        return QMLKernelData.from_quantum_job(
+            device.run(
+                create_inner_product_circuit(self.params.num_qubits), shots=self.params.shots
+            )
         )
 
     def poll_handler(

--- a/metriq_gym/benchmarks/quantum_volume.py
+++ b/metriq_gym/benchmarks/quantum_volume.py
@@ -199,14 +199,8 @@ class QuantumVolume(Benchmark):
         shots = self.params.shots
         trials = self.params.trials
         circuits, ideal_probs = prepare_qv_circuits(n=num_qubits, num_trials=trials)
-        quantum_job: QuantumJob | list[QuantumJob] = device.run(circuits, shots=shots)
-        provider_job_ids = (
-            [quantum_job.id]
-            if isinstance(quantum_job, QuantumJob)
-            else [job.id for job in quantum_job]
-        )
-        return QuantumVolumeData(
-            provider_job_ids=provider_job_ids,
+        return QuantumVolumeData.from_quantum_job(
+            quantum_job=device.run(circuits, shots=shots),
             num_qubits=num_qubits,
             shots=shots,
             depth=num_qubits,

--- a/metriq_gym/benchmarks/wormhole.py
+++ b/metriq_gym/benchmarks/wormhole.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from qiskit import QuantumCircuit
 from qbraid import GateModelResultData, QuantumDevice, QuantumJob
 from qbraid.runtime.result_data import MeasCount
-from metriq_gym.helpers.task_helpers import flatten_counts, flatten_job_ids
+from metriq_gym.helpers.task_helpers import flatten_counts
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
 
 
@@ -240,11 +240,9 @@ class Wormhole(Benchmark):
     """Benchmark class for Wormhole experiments."""
 
     def dispatch_handler(self, device: QuantumDevice) -> WormholeData:
-        """Runs the benchmark and returns job metadata."""
-        quantum_job: QuantumJob | list[QuantumJob] = device.run(
-            wormhole_circuit(self.params.num_qubits), shots=self.params.shots
+        return WormholeData.from_quantum_job(
+            device.run(wormhole_circuit(self.params.num_qubits), shots=self.params.shots)
         )
-        return WormholeData(provider_job_ids=flatten_job_ids(quantum_job))
 
     def poll_handler(
         self,

--- a/metriq_gym/helpers/task_helpers.py
+++ b/metriq_gym/helpers/task_helpers.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterable
-from qbraid import QuantumJob
 from qbraid.runtime.result_data import MeasCount, GateModelResultData
 
 
@@ -18,12 +16,3 @@ def flatten_counts(result_data: list[GateModelResultData]) -> list[MeasCount]:
         elif result.measurement_counts is not None:
             flat_counts.append(result.measurement_counts)
     return flat_counts
-
-
-def flatten_job_ids(quantum_job: QuantumJob | Iterable[QuantumJob]) -> list[str]:
-    if isinstance(quantum_job, QuantumJob):
-        return [quantum_job.id]
-    elif isinstance(quantum_job, Iterable):
-        return [job.id for job in quantum_job]
-    else:
-        raise TypeError(f"Unsupported job type: {type(quantum_job)}")

--- a/tests/unit/benchmarks/test_benchmark.py
+++ b/tests/unit/benchmarks/test_benchmark.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+from dataclasses import dataclass
+
+from qbraid import QuantumJob
+from metriq_gym.benchmarks.benchmark import BenchmarkData
+
+
+class TestBenchmarkData:
+    def test_from_quantum_job_single(self):
+        TEST_JOB_ID = "test_job_id"
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = TEST_JOB_ID
+        data = BenchmarkData.from_quantum_job(mock_job)
+        assert data.provider_job_ids == [TEST_JOB_ID]
+
+    def test_from_quantum_job_iterable(self):
+        TEST_JOB_IDS = ["job1", "job2"]
+        mock_job1 = MagicMock(spec=QuantumJob)
+        mock_job1.id = TEST_JOB_IDS[0]
+        mock_job2 = MagicMock(spec=QuantumJob)
+        mock_job2.id = TEST_JOB_IDS[1]
+        jobs = [mock_job1, mock_job2]
+        data = BenchmarkData.from_quantum_job(jobs)
+        assert data.provider_job_ids == TEST_JOB_IDS
+
+    def test_from_quantum_job_with_kwargs(self):
+        @dataclass
+        class CustomBenchmarkData(BenchmarkData):
+            extra: int = 0
+
+        TEST_JOB_ID = "job_with_extra"
+        mock_job = MagicMock(spec=QuantumJob)
+        mock_job.id = TEST_JOB_ID
+        data = CustomBenchmarkData.from_quantum_job(mock_job, extra=42)
+        assert data.provider_job_ids == [TEST_JOB_ID]
+        assert data.extra == 42

--- a/tests/unit/benchmarks/test_mirror_circuits.py
+++ b/tests/unit/benchmarks/test_mirror_circuits.py
@@ -7,6 +7,7 @@ for more efficient and lightweight simulation in testing.
 """
 
 import pytest
+from qbraid import QuantumJob
 import rustworkx as rx
 import numpy as np
 from unittest.mock import MagicMock, patch
@@ -306,12 +307,10 @@ class TestMirrorCircuitsBenchmark:
         return MirrorCircuits(args, mock_params_minimal)
 
     @patch("metriq_gym.benchmarks.mirror_circuits.connectivity_graph")
-    @patch("metriq_gym.benchmarks.mirror_circuits.flatten_job_ids")
     @patch("metriq_gym.benchmarks.mirror_circuits.generate_mirror_circuit")
     def test_dispatch_handler(
         self,
         mock_generate_circuit,
-        mock_flatten_job_ids,
         mock_connectivity_graph,
         benchmark,
         mock_device,
@@ -326,12 +325,9 @@ class TestMirrorCircuitsBenchmark:
         mock_generate_circuit.return_value = (mock_circuit, "001")
 
         # Mock device.run
-        mock_job = MagicMock()
+        mock_job = MagicMock(spec=QuantumJob)
         mock_job.id = "test_job_id"
         mock_device.run.return_value = mock_job
-
-        # Mock flatten_job_ids to return the expected result
-        mock_flatten_job_ids.return_value = ["test_job_id"]
 
         result = benchmark.dispatch_handler(mock_device)
 


### PR DESCRIPTION
# Description

It was not intuitive for benchmarks developer that they were supposed to call the flatten_job_id functions. This makes the API more intuitive with a new way to construct an intermediate dataclass instance starting from a qBraid quantum job object.

This can be improved further, but it's a step forward imho.

# Type of change
Refactoring change

# How Has This Been Tested?

unit + e2e tests

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
