### PR TITLE
chore: add rtd yml config.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,4 +6,4 @@ build:
     python: "3.13"
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
In order for RTD to work, we first need the `.readthedocs.yaml` file on the `main` branch:


<img width="806" alt="Screenshot 2025-06-27 at 5 03 27 PM" src="https://github.com/user-attachments/assets/2792151a-a111-42d7-b08f-abd3399d618e" />
