### PR TITLE
chore: add e2e mvp mgym notebook tutorial

### DIFF
--- a/docs/source/end_to_end_tutorial.ipynb
+++ b/docs/source/end_to_end_tutorial.ipynb
@@ -1,0 +1,271 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "810ca4c7",
+   "metadata": {},
+   "source": [
+    "# End-to-End Tutorial for Metriq-Gym"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "541f097d",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we will provide a comprehensive end-to-end example of how to use the **metriq-gym** package to run a quantum benchmark. This will include setting up the environment, defining a benchmark, and executing it on a quantum device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1b3a228d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from types import SimpleNamespace\n",
+    "from dotenv import load_dotenv\n",
+    "from metriq_gym.run import dispatch_job, poll_job, view_job\n",
+    "from metriq_gym.job_manager import JobManager"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e8a8968",
+   "metadata": {},
+   "source": [
+    "First, ensure you have a local `.env` file in the root directory of the project with your device credentials for your\n",
+    "account specified. The format of this file can be found in `.env.example`. Assuming you have the necessary credentials,\n",
+    "the next line will load them into the environment.\n",
+    "\n",
+    "Please refer to the [user guide](https://metriq-gym.readthedocs.io/en/latest/user_guide.html) or README for more details on how to set up your environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "87eed0b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load environment variables from .env file.\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65a8f37c",
+   "metadata": {},
+   "source": [
+    "## Job handling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7062d70",
+   "metadata": {},
+   "source": [
+    "Metriq-Gym provides a simple API to dispatch jobs to quantum devices and to poll and view their status."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b74f79a",
+   "metadata": {},
+   "source": [
+    "### Dispatch job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55d0bac9",
+   "metadata": {},
+   "source": [
+    "We can use the Python interface to dispatch a job to a quantum device or local simulator. For the sake of example, we will use the local simulator, but the `provider_name` and `device_name` can be changed to target a specific quantum device (assuming you have the necessary credentials in your `.env` file).\n",
+    "\n",
+    "Metriq-Gm provides a suite of benchmarks that can be used to test the performance of quantum devices. In this example, we will use the `wormhole` benchmark, which is a simple benchmark that tests the performance of a quantum device on a specific task. The specification for this benchmark can be found in the `metriq_gym/schemas/examples/wormhole.example.json` file.\n",
+    "\n",
+    "More information about the `wormhole` benchmark can be found in `benchmarks/wormhole.py` as well as in the paper on which it is based: [arXiv:2205.14081](https://arxiv.org/abs/2205.14081)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "24a167e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting job dispatch...\n",
+      "Dispatching Wormhole benchmark from ../../metriq_gym/schemas/examples/wormhole.example.json on aer_simulator...\n",
+      "\n",
+      "Summary:\n",
+      "  ✓ Wormhole (../../metriq_gym/schemas/examples/wormhole.example.json) dispatched with ID: bf601420-3ab6-45be-bbfc-2d7ac4e569c6\n",
+      "\n",
+      "Successfully dispatched 1/1 benchmarks.\n",
+      "Use 'mgym poll' to check job status.\n"
+     ]
+    }
+   ],
+   "source": [
+    "job_manager = JobManager()\n",
+    "benchmark_files = [\"../../metriq_gym/schemas/examples/wormhole.example.json\"]\n",
+    "provider_name = \"local\"\n",
+    "device_name = \"aer_simulator\"\n",
+    "\n",
+    "dispatch_config = SimpleNamespace(\n",
+    "    benchmark_configs=benchmark_files,\n",
+    "    provider=provider_name,\n",
+    "    device=device_name,\n",
+    ")\n",
+    "\n",
+    "dispatch_job(dispatch_config, job_manager)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "138c603a",
+   "metadata": {},
+   "source": [
+    "We can see that the `wormhole` benchmark has been successfully dispatched to the local simulator. Dispatching a job creates a local `.jsonl` jobs data file that captures all of the metadata of the job we just launched. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0d0503e",
+   "metadata": {},
+   "source": [
+    "### View job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b326714e",
+   "metadata": {},
+   "source": [
+    "Now that we have dispatched the job, we can poll its status. The `JobManager` class provides a simple interface to poll the status of jobs. We can use the `get_jobs` method to get the list of jobs and their statuses. In this example, we will poll the status of the job we just dispatched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "72d55a0b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒══════════════════╤════════════════════════════════════════════════════════════════╕\n",
+      "│ id               │ bf601420-3ab6-45be-bbfc-2d7ac4e569c6                           │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ job_type         │ Wormhole                                                       │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ params           │ {'benchmark_name': 'Wormhole', 'num_qubits': 7, 'shots': 8192} │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ provider_name    │ local                                                          │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ device_name      │ aer_simulator                                                  │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ provider_job_ids │ ['a8d46bdc2705410d867c6d10e3fefcb3']                           │\n",
+      "├──────────────────┼────────────────────────────────────────────────────────────────┤\n",
+      "│ dispatch_time    │ 2025-07-24T19:25:36.082623                                     │\n",
+      "╘══════════════════╧════════════════════════════════════════════════════════════════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "jobs = job_manager.get_jobs()\n",
+    "job_id_to_poll = jobs[-1].id\n",
+    "\n",
+    "job_config = SimpleNamespace(job_id=job_id_to_poll)\n",
+    "\n",
+    "view_job(job_config, job_manager)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e78e1f1",
+   "metadata": {},
+   "source": [
+    "### Poll job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5094ea2",
+   "metadata": {},
+   "source": [
+    "Polling a job allows us to check its status and retrieve the results once it has completed. The `poll_job` function can be used to poll the job until it is completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ec0c98cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Polling job...\n",
+      "{'device': 'aer_simulator',\n",
+      " 'job_type': 'Wormhole',\n",
+      " 'provider': 'local',\n",
+      " 'results': {'expectation_value': 0.9967041015625},\n",
+      " 'timestamp': '2025-07-24T19:25:36.082623',\n",
+      " 'version': '0.1.2'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "poll_job(job_config, job_manager)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf28d93",
+   "metadata": {},
+   "source": [
+    "In the case of the `wormhole` benchmark, we can see that the job has been successfully dispatched and polled. The polled result contains information about when the result was obtained, any relevant results from the benchmark, etc. The ideal (or perfect) result expectation value for the `wormhole` benchmark is `1.0` and we can see that the simulated result is very close to this value. \n",
+    "\n",
+    "Explaining the `wormhole` benchmark in detail is beyond the scope of this tutorial, but it is a simple benchmark that tests the performance of a quantum device on a specific task. The specification for this benchmark can be found in the `metriq_gym/schemas/examples/wormhole.example.json` file."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "metriq-gym-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ To install ``metriq-gym`` run ::
 
    API-doc <api.rst>
    User Guide <user_guide.rst>
+   End-to-End Tutorial <end_to_end_tutorial>
    Adding a new benchmark <adding_new_benchmark.rst>
 
 


### PR DESCRIPTION
- Adding mvp notebook tutorial which provides an e2e self-contained set of examples of dispatching, viewing, and polling metriq-gym jobs.