### PR TITLE
docs: Fix README typos (closes #452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ To run on IBM hardware, you will also require an IBM token. To obtain this, plea
 Platform](https://quantum.ibm.com/) and include the API token in the local `.env` file as previously described.
 
 The `schemas/examples/` directory houses example JSON configuration files that define the benchmark to run. In this
-case, we use the `bseq_example.json` file as we want to run a BSEQ job. The following dispatches a
+case, we use the `bseq.example.json` file as we want to run a BSEQ job. The following dispatches a
 job on the ibm-sherbrooke device for BSEQ.
 
 ```sh
@@ -292,7 +292,7 @@ poetry run mypy
 The project uses [Sphinx](https://www.sphinx-doc.org/en/master/) to generate documentation. To build the HTML
 documentation:
 
-1.Navigate to the docs/ directory:
+1. Navigate to the docs/ directory:
 ```sh
 cd docs/
 ```


### PR DESCRIPTION
# Description

This pull request addresses two minor issues in the README.md file to improve clarity and accuracy.

The schemas/examples/ directory's reference to bseq_example.json has been corrected to bseq.example.json to match the actual file name. Additionally, a missing space after the step number in the "Documentation" section (specifically "1.Navigate...") has been added for better formatting.

No dependencies are required for this change.

# Issue ticket number and link

Fixes #452

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change involves only documentation (README.md) updates.
I have verified the changes locally by opening the README.md file in a Markdown viewer to confirm that the file path is now correct and the spacing after the step number is properly rendered.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
