### PR TITLE
Fix/incorrect log format

### DIFF
--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -116,7 +116,7 @@ class JobManager:
                 except TypeError as e:
                     self._log_skip(line_number, f"Data structure mismatch: {e}")
                 except Exception as e:
-                    logger.warning(line_number, f"Unexpected exception ({type(e).__name__}): {e}")
+                    logger.warning(f"{line_number}Unexpected exception ({type(e).__name__}): {e}")
                 else:
                     self.jobs.append(job)
 

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -116,7 +116,7 @@ class JobManager:
                 except TypeError as e:
                     self._log_skip(line_number, f"Data structure mismatch: {e}")
                 except Exception as e:
-                    logger.warning(f"{line_number}Unexpected exception ({type(e).__name__}): {e}")
+                    logger.warning(f"{line_number} Unexpected exception ({type(e).__name__}): {e}")
                 else:
                     self.jobs.append(job)
 


### PR DESCRIPTION
# Description

This pr fixes the incorrect logging statement in the  `job_manager`
The `line_number` was previously passed as a separate argument to `logger.warning`. This change moves the `line_number` inside the f-string, ensuring the entire log message is correctly formatted as a single string.

# Issue ticket number and link

Fixes #454 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Given the small scope of this change , no new tests were added.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
