### PR TITLE
fix: fixing the issue with running a noisy sim

### DIFF
--- a/metriq_gym/local/provider.py
+++ b/metriq_gym/local/provider.py
@@ -25,7 +25,11 @@ class LocalProvider(QuantumProvider):
             service = QiskitRuntimeService()
             backend = service.backend(device_id)
             noise_model = NoiseModel.from_backend(backend)
-            aer_backend = AerSimulator.from_backend(backend, noise_model=noise_model)
+            aer_backend = AerSimulator.from_backend(
+                backend,
+                noise_model=noise_model,
+                basis_gates=AerSimulator().configuration().basis_gates,
+            )
         except Exception as exc:  # pragma: no cover - network exceptions
             raise ValueError("Unknown device identifier") from exc
 


### PR DESCRIPTION
Closes #464 

Previously, running
```
➜  metriq-gym git:(main) ✗ poetry run mgym dispatch metriq_gym/schemas/examples/wormhole.example.json --provider local --device ibm_sherbrooke
Starting job dispatch...
Dispatching Wormhole benchmark from metriq_gym/schemas/examples/wormhole.example.json on ibm_sherbrooke...

Summary:
  ✗ metriq_gym/schemas/examples/wormhole.example.json failed: AerError: 'unknown instruction: h'

Successfully dispatched 0/1 benchmarks.
```
would not launch the noisy sim successfully due to the basis gates on the device not being properly accounted for. Now, with this change, we have that

```
➜  metriq-gym git:(main) ✗ poetry run mgym dispatch metriq_gym/schemas/examples/wormhole.example.json --provider local --device ibm_sherbrooke
Starting job dispatch...
Dispatching Wormhole benchmark from metriq_gym/schemas/examples/wormhole.example.json on ibm_sherbrooke...

Summary:
  ✓ Wormhole (metriq_gym/schemas/examples/wormhole.example.json) dispatched with ID: aa6e645e-388b-472f-83cd-955deb18cfc5

Successfully dispatched 1/1 benchmarks.
```