### PR TITLE
fix: version pinned to dispatch

### DIFF
--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -11,7 +11,7 @@ class BaseExporter(ABC):
 
     def as_dict(self):
         return {
-            "version": self.metriq_gym_job.app_version,
+            "app_version": self.metriq_gym_job.app_version,
             "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
             "provider": self.metriq_gym_job.provider_name,
             "device": self.metriq_gym_job.device_name,

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-import importlib.metadata
 from metriq_gym.benchmarks.benchmark import BenchmarkResult
 from metriq_gym.job_manager import MetriqGymJob
 
@@ -12,7 +11,7 @@ class BaseExporter(ABC):
 
     def as_dict(self):
         return {
-            "version": importlib.metadata.version("metriq-gym"),
+            "version": self.metriq_gym_job.version,
             "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
             "provider": self.metriq_gym_job.provider_name,
             "device": self.metriq_gym_job.device_name,

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -11,7 +11,7 @@ class BaseExporter(ABC):
 
     def as_dict(self):
         return {
-            "version": self.metriq_gym_job.version,
+            "app_version": self.metriq_gym_job.app_version,
             "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
             "provider": self.metriq_gym_job.provider_name,
             "device": self.metriq_gym_job.device_name,

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -11,7 +11,7 @@ class BaseExporter(ABC):
 
     def as_dict(self):
         return {
-            "app_version": self.metriq_gym_job.app_version,
+            "version": self.metriq_gym_job.app_version,
             "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
             "provider": self.metriq_gym_job.provider_name,
             "device": self.metriq_gym_job.device_name,

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -1,5 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
+import importlib.metadata
 import json
 import os
 import pprint
@@ -23,6 +24,7 @@ class MetriqGymJob:
     provider_name: str
     device_name: str
     dispatch_time: datetime
+    version: str = field(default_factory=lambda: importlib.metadata.version("metriq-gym"))
     result_data: list[dict[str, Any]] | None = None
 
     def to_table_row(self) -> list[str]:
@@ -40,7 +42,8 @@ class MetriqGymJob:
     @staticmethod
     def deserialize(data: str) -> "MetriqGymJob":
         job_dict = json.loads(data)
-        job = MetriqGymJob(**job_dict)
+        version = job_dict.get("version", importlib.metadata.version("metriq-gym"))
+        job = MetriqGymJob(**{**job_dict, "version": version})
         job.job_type = JobType(job_dict["job_type"])
         job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
         return job

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -44,11 +44,9 @@ class MetriqGymJob:
     @staticmethod
     def deserialize(data: str) -> "MetriqGymJob":
         job_dict = json.loads(data)
-        app_version = job_dict.get("app_version")
-        job = MetriqGymJob(**{**job_dict, "app_version": app_version})
-        job.job_type = JobType(job_dict["job_type"])
-        job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
-        return job
+        job_dict["job_type"] = JobType(job_dict["job_type"])
+        job_dict["dispatch_time"] = datetime.fromisoformat(job_dict["dispatch_time"])
+        return MetriqGymJob(**job_dict)
 
     def __str__(self) -> str:
         rows = [

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -24,7 +24,9 @@ class MetriqGymJob:
     provider_name: str
     device_name: str
     dispatch_time: datetime
-    version: str = field(default_factory=lambda: importlib.metadata.version("metriq-gym"))
+    app_version: str | None = field(
+        default_factory=lambda: importlib.metadata.version("metriq-gym")
+    )
     result_data: list[dict[str, Any]] | None = None
 
     def to_table_row(self) -> list[str]:
@@ -42,8 +44,8 @@ class MetriqGymJob:
     @staticmethod
     def deserialize(data: str) -> "MetriqGymJob":
         job_dict = json.loads(data)
-        version = job_dict.get("version", importlib.metadata.version("metriq-gym"))
-        job = MetriqGymJob(**{**job_dict, "version": version})
+        app_version = job_dict.get("app_version")
+        job = MetriqGymJob(**{**job_dict, "app_version": app_version})
         job.job_type = JobType(job_dict["job_type"])
         job.dispatch_time = datetime.fromisoformat(job_dict["dispatch_time"])
         return job

--- a/tests/unit/test_job_manager.py
+++ b/tests/unit/test_job_manager.py
@@ -183,7 +183,7 @@ def test_delete_job(job_manager, sample_job):
     assert len(jobs) == 0
 
 
-def test_job_version_serialization_and_export(monkeypatch):
+def test_job_app_version_serialization_and_export(monkeypatch):
     """Ensure stored version persists across serialization and is used by exporters."""
     import importlib.metadata
     from metriq_gym.exporters.json_exporter import JsonExporter
@@ -200,12 +200,12 @@ def test_job_version_serialization_and_export(monkeypatch):
         dispatch_time=datetime.now(),
     )
 
-    assert job.version == "1.0"
+    assert job.app_version == "1.0"
     serialized = job.serialize()
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "2.0")
     loaded_job = MetriqGymJob.deserialize(serialized)
-    assert loaded_job.version == "1.0"
+    assert loaded_job.app_version == "1.0"
 
     exporter = JsonExporter(loaded_job, BenchmarkResult())
     export_dict = exporter.as_dict()

--- a/tests/unit/test_job_manager.py
+++ b/tests/unit/test_job_manager.py
@@ -209,4 +209,4 @@ def test_job_app_version_serialization_and_export(monkeypatch):
 
     exporter = JsonExporter(loaded_job, BenchmarkResult())
     export_dict = exporter.as_dict()
-    assert export_dict["version"] == "1.0"
+    assert export_dict["app_version"] == "1.0"

--- a/tests/unit/test_job_manager.py
+++ b/tests/unit/test_job_manager.py
@@ -189,7 +189,7 @@ def test_job_app_version_serialization_and_export(monkeypatch):
     from metriq_gym.exporters.json_exporter import JsonExporter
     from metriq_gym.benchmarks.benchmark import BenchmarkResult
 
-    monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.0")
+    monkeypatch.setattr(importlib.metadata, "app_version", lambda _: "1.0")
     job = MetriqGymJob(
         id="ver_job",
         provider_name="provider",
@@ -203,10 +203,10 @@ def test_job_app_version_serialization_and_export(monkeypatch):
     assert job.app_version == "1.0"
     serialized = job.serialize()
 
-    monkeypatch.setattr(importlib.metadata, "version", lambda _: "2.0")
+    monkeypatch.setattr(importlib.metadata, "app_version", lambda _: "2.0")
     loaded_job = MetriqGymJob.deserialize(serialized)
     assert loaded_job.app_version == "1.0"
 
     exporter = JsonExporter(loaded_job, BenchmarkResult())
     export_dict = exporter.as_dict()
-    assert export_dict["version"] == "1.0"
+    assert export_dict["app_version"] == "1.0"

--- a/tests/unit/test_job_manager.py
+++ b/tests/unit/test_job_manager.py
@@ -189,7 +189,7 @@ def test_job_app_version_serialization_and_export(monkeypatch):
     from metriq_gym.exporters.json_exporter import JsonExporter
     from metriq_gym.benchmarks.benchmark import BenchmarkResult
 
-    monkeypatch.setattr(importlib.metadata, "app_version", lambda _: "1.0")
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.0")
     job = MetriqGymJob(
         id="ver_job",
         provider_name="provider",
@@ -203,10 +203,10 @@ def test_job_app_version_serialization_and_export(monkeypatch):
     assert job.app_version == "1.0"
     serialized = job.serialize()
 
-    monkeypatch.setattr(importlib.metadata, "app_version", lambda _: "2.0")
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "2.0")
     loaded_job = MetriqGymJob.deserialize(serialized)
     assert loaded_job.app_version == "1.0"
 
     exporter = JsonExporter(loaded_job, BenchmarkResult())
     export_dict = exporter.as_dict()
-    assert export_dict["app_version"] == "1.0"
+    assert export_dict["version"] == "1.0"


### PR DESCRIPTION
Closes: #466 

- Pins the version number used to dispatch the job in the result output
- Added tests to ensure that when polling via different versions does not impact the dispatched version