### PR TITLE
Only Importing Necessary Packages From QED-C Submodule.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ mgym = "metriq_gym.run:main"
 packages = [
     { include = "metriq_gym", from = "." },
     { include = "qiskit_device_benchmarking", from = "submodules/qiskit-device-benchmarking" },
-    { include = "*", from = "submodules/QC-App-Oriented-Benchmarks" }
+    { include = "_common", from = "submodules/QC-App-Oriented-Benchmarks" },
+    { include = "bernstein_vazirani", from = "submodules/QC-App-Oriented-Benchmarks" },
+    { include = "phase_estimation", from = "submodules/QC-App-Oriented-Benchmarks" },
+    { include = "hidden_shift", from = "submodules/QC-App-Oriented-Benchmarks" },
+    { include = "quantum_fourier_transform", from = "submodules/QC-App-Oriented-Benchmarks" }
 ]
 include = [
     { path = "LICENSE", format = ["sdist", "wheel"] },


### PR DESCRIPTION
# Description

The size of the wheel is too large after including the QED-C submodule. The `pyproject.toml` file was altered to include strictly necessary packages for BV, PE, HS, and QFT benchmarks. This reduces the size of the wheel to `350,388 bytes (352 KB on disk)`. 

No new dependencies are required for this change. 

# Issue ticket number and link

Fixes #473

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All QED-C benchmarks were dispatched and polled to ensure functionality after rebuilding the wheel. No new configurations are required for testing.  

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
