### PR TITLE
feat: Basic suite implementation

### DIFF
--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -140,6 +140,14 @@ def parse_arguments() -> argparse.Namespace:
         help="Suite ID to view jobs for",
     )
 
+    suite_delete = suite_subparsers.add_parser("delete", help="Delete a suite")
+    suite_delete.add_argument(
+        "suite_id",
+        type=str,
+        nargs="?",
+        help="Suite ID to delete",
+    )
+
     # Job resource group
     job_parser = resource_parsers.add_parser("job", help="Job operations")
     job_subparsers = job_parser.add_subparsers(dest="action", required=True, help="Job action")

--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -91,90 +91,90 @@ def parse_arguments() -> argparse.Namespace:
         - Same benchmark type can be run multiple times with different configurations
     """
     parser = argparse.ArgumentParser(description="Metriq-Gym benchmarking CLI")
-    subparsers = parser.add_subparsers(dest="action", required=True, help="Action to perform")
-
-    dispatch_parser = subparsers.add_parser("dispatch", help="Dispatch jobs")
-    dispatch_subparsers = dispatch_parser.add_subparsers(
-        dest="dispatch_action", required=True, help="Action to perform"
-    )
-    job_dispatch_subparser = dispatch_subparsers.add_parser("job", help="Dispatch a single job")
-    suite_dispatch_subparser = dispatch_subparsers.add_parser(
-        "suite", help="Dispatch a suite of jobs"
+    resource_parsers = parser.add_subparsers(
+        dest="resource", required=True, help="Resource (suite/job)"
     )
 
-    job_dispatch_subparser.add_argument(
-        "config",
+    # Suite resource group
+    suite_parser = resource_parsers.add_parser("suite", help="Suite operations")
+    suite_subparsers = suite_parser.add_subparsers(
+        dest="action", required=True, help="Suite action"
+    )
+
+    suite_dispatch = suite_subparsers.add_parser("dispatch", help="Dispatch a suite of jobs")
+    suite_dispatch.add_argument("suite_config", type=str, help="Path to suite configuration file.")
+    suite_dispatch.add_argument(
+        "-p",
+        "--provider",
         type=str,
-        help="Path to job configuration file.",
+        choices=get_providers() + ["local"],
+        help="String identifier for backend provider service",
     )
-
-    suite_dispatch_subparser.add_argument(
-        "suite_config",
+    suite_dispatch.add_argument(
+        "-d",
+        "--device",
         type=str,
-        help="Path to suite configuration file.",
+        help="Backend to use",
     )
 
-    for subparser in [job_dispatch_subparser, suite_dispatch_subparser]:
-        subparser.add_argument(
-            "-p",
-            "--provider",
-            type=str,
-            choices=get_providers() + ["local"],
-            help="String identifier for backend provider service",
-        )
-        subparser.add_argument(
-            "-d",
-            "--device",
-            type=str,
-            help="Backend to use",
-        )
-
-    poll_parser = subparsers.add_parser("poll", help="Poll jobs")
-    poll_subparsers = poll_parser.add_subparsers(
-        dest="poll_action", required=True, help="Action to perform"
-    )
-
-    suite_poll_subparser = poll_subparsers.add_parser("suite", help="Get suite results")
-    job_poll_subparser = poll_subparsers.add_parser("job", help="Get job results")
-
-    job_poll_subparser.add_argument(
-        JOB_ID_ARGUMENT_NAME, type=str, nargs="?", help="Job ID to poll (optional)"
-    )
-    suite_poll_subparser.add_argument(
+    suite_poll = suite_subparsers.add_parser("poll", help="Poll suite jobs")
+    suite_poll.add_argument(
         "suite_id",
         type=str,
         nargs="?",
         help="Suite ID to poll results for",
     )
-
-    for subparser in [job_poll_subparser, suite_poll_subparser]:
-        subparser.add_argument(
-            "--json",
-            nargs="?",
-            required=False,
-            default=argparse.SUPPRESS,
-            help="Export results to JSON file (optional)",
-        )
-
-    view_parser = subparsers.add_parser("view", help="View jobs")
-    view_subparsers = view_parser.add_subparsers(
-        dest="view_action", required=True, help="Action to perform"
+    suite_poll.add_argument(
+        "--json",
+        nargs="?",
+        required=False,
+        default=argparse.SUPPRESS,
+        help="Export results to JSON file (optional)",
     )
-    suite_view_subparser = view_subparsers.add_parser("suite", help="View suite jobs")
-    job_view_subparser = view_subparsers.add_parser("job", help="View job details")
-    job_view_subparser.add_argument(
-        JOB_ID_ARGUMENT_NAME, type=str, nargs="?", help="Job ID to view (optional)"
-    )
-    suite_view_subparser.add_argument(
+
+    suite_view = suite_subparsers.add_parser("view", help="View suite jobs")
+    suite_view.add_argument(
         "suite_id",
         type=str,
         nargs="?",
         help="Suite ID to view jobs for",
     )
 
-    delete_parser = subparsers.add_parser("delete", help="Delete jobs")
-    delete_parser.add_argument(
-        JOB_ID_ARGUMENT_NAME, type=str, nargs="?", help="Job ID to delete (optional)"
+    # Job resource group
+    job_parser = resource_parsers.add_parser("job", help="Job operations")
+    job_subparsers = job_parser.add_subparsers(dest="action", required=True, help="Job action")
+
+    job_dispatch = job_subparsers.add_parser("dispatch", help="Dispatch a single job")
+    job_dispatch.add_argument("config", type=str, help="Path to job configuration file.")
+    job_dispatch.add_argument(
+        "-p",
+        "--provider",
+        type=str,
+        choices=get_providers() + ["local"],
+        help="String identifier for backend provider service",
+    )
+    job_dispatch.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        help="Backend to use",
+    )
+
+    job_poll = job_subparsers.add_parser("poll", help="Poll job")
+    job_view = job_subparsers.add_parser("view", help="View job")
+    job_delete = job_subparsers.add_parser("delete", help="Delete job")
+
+    for subparser in [job_poll, job_view, job_delete]:
+        subparser.add_argument(
+            JOB_ID_ARGUMENT_NAME, type=str, nargs="?", help="Job ID to operate on (optional)"
+        )
+
+    job_poll.add_argument(
+        "--json",
+        nargs="?",
+        required=False,
+        default=argparse.SUPPRESS,
+        help="Export results to JSON file (optional)",
     )
 
     return parser.parse_args()

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -4,9 +4,9 @@ from metriq_gym.job_manager import MetriqGymJob
 
 
 class BaseExporter(ABC):
-    def __init__(self, metriq_gym_job: MetriqGymJob, results: BenchmarkResult):
+    def __init__(self, metriq_gym_job: MetriqGymJob, result: BenchmarkResult):
         self.metriq_gym_job = metriq_gym_job
-        self.results = results
+        self.result = result
         super().__init__()
 
     def as_dict(self):
@@ -14,9 +14,10 @@ class BaseExporter(ABC):
             "app_version": self.metriq_gym_job.app_version,
             "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
             "provider": self.metriq_gym_job.provider_name,
+            "suite_id": self.metriq_gym_job.suite_id,
             "device": self.metriq_gym_job.device_name,
             "job_type": self.metriq_gym_job.job_type.value,
-            "results": dict(self.results),
+            "results": dict(self.result),
         }
 
     @abstractmethod

--- a/metriq_gym/exporters/dict_exporter.py
+++ b/metriq_gym/exporters/dict_exporter.py
@@ -1,0 +1,7 @@
+from typing import Any
+from metriq_gym.exporters.base_exporter import BaseExporter
+
+
+class DictExporter(BaseExporter):
+    def export(self) -> dict[str, Any]:
+        return self.as_dict()

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -23,10 +23,17 @@ class MetriqGymJob:
     provider_name: str
     device_name: str
     dispatch_time: datetime
+    suite_id: str | None = None
     result_data: list[dict[str, Any]] | None = None
 
-    def to_table_row(self) -> list[str]:
-        return [
+    def to_table_row(self, show_suite_id: bool) -> list[str | None]:
+        return (
+            [
+                self.suite_id,
+            ]
+            if show_suite_id
+            else []
+        ) + [
             self.id,
             self.provider_name,
             self.device_name,
@@ -46,7 +53,8 @@ class MetriqGymJob:
         return job
 
     def __str__(self) -> str:
-        rows = [
+        rows: list[list[str | None]] = [
+            ["suite_id", self.suite_id],
             ["id", self.id],
             ["job_type", self.job_type.value],
             ["params", pprint.pformat(self.params)],
@@ -141,6 +149,9 @@ class JobManager:
             if job.id == job_id:
                 return job
         raise ValueError(f"Job with id {job_id} not found")
+
+    def get_jobs_by_suite_id(self, suite_id: str) -> list[MetriqGymJob]:
+        return [job for job in self.jobs if job.suite_id == suite_id]
 
     def delete_job(self, job_id: str) -> None:
         self.jobs = [job for job in self.jobs if job.id != job_id]

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -209,9 +209,7 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
 
         except Exception as e:
             error_details = f"{type(e).__name__}: {str(e)}"
-            results.append(
-                f"✗ {benchmark_entry.name} ({params.benchmark_name}) from {suite.name} failed: {error_details}"
-            )
+            results.append(f"✗ {benchmark_entry.name} from {suite.name} failed: {error_details}")
 
     print("\nSummary:")
     for result in results:
@@ -252,10 +250,6 @@ def poll_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
         else:
             results.append(result)
     export_suite_results(args, jobs, results)
-
-
-def aggregate_results(results: list[BenchmarkResult]) -> BenchmarkResult:
-    raise NotImplementedError("Aggregate results logic is not implemented yet.")
 
 
 def print_selected(d, selected_keys):

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -319,33 +319,31 @@ def delete_job(args: argparse.Namespace, job_manager: JobManager) -> None:
 
 
 def main() -> int:
-    """Main entry point for the CLI."""
     load_dotenv()
     args = parse_arguments()
     job_manager = JobManager()
 
-    if args.action == "dispatch":
-        if args.dispatch_action == "suite":
-            dispatch_suite(args, job_manager)
-        elif args.dispatch_action == "job":
-            dispatch_job(args, job_manager)
-    elif args.action == "view":
-        if args.view_action == "suite":
-            view_suite(args, job_manager)
-        elif args.view_action == "job":
-            view_job(args, job_manager)
-    elif args.action == "poll":
-        if args.poll_action == "suite":
-            poll_suite(args, job_manager)
-        elif args.poll_action == "job":
-            poll_job(args, job_manager)
-    elif args.action == "delete":
-        delete_job(args, job_manager)
-    else:
-        logging.error("Invalid action specified. Run with --help for usage information.")
-        return 1
+    RESOURCE_ACTION_TABLE = {
+        "suite": {
+            "dispatch": dispatch_suite,
+            "poll": poll_suite,
+        },
+        "job": {
+            "dispatch": dispatch_job,
+            "poll": poll_job,
+            "view": view_job,
+            "delete": delete_job,
+        },
+    }
 
-    return 0
+    resource_table = RESOURCE_ACTION_TABLE.get(args.resource)
+    if resource_table:
+        action_handler = resource_table.get(args.action)
+        if action_handler:
+            action_handler(args, job_manager)
+            return 0
+    logging.error("Invalid command. Run with --help for usage information.")
+    return 1
 
 
 if __name__ == "__main__":

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -310,7 +310,7 @@ def fetch_result(metriq_job: MetriqGymJob, args: argparse.Namespace) -> Benchmar
         result: BenchmarkResult = handler.poll_handler(job_data, result_data, quantum_jobs)
         return result
     else:
-        print("Job is not yet completed. Current status:")
+        print("Job is not yet completed. Current status of tasks:")
         for task in quantum_jobs:
             info = job_status(task)
             msg = f"- {task.id}: {info.status.value}"

--- a/metriq_gym/suite_parser.py
+++ b/metriq_gym/suite_parser.py
@@ -1,18 +1,18 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from pydantic import BaseModel, Field
 
 
 class BenchmarkEntry(BaseModel):
     name: str = Field(..., description="Unique name for the benchmark in the suite")
-    config: Dict[str, Any] = Field(..., description="Benchmark configuration dictionary")
+    config: dict[str, Any] = Field(..., description="Benchmark configuration dictionary")
 
 
 class Suite(BaseModel):
     name: str = Field(..., description="Suite name")
-    benchmarks: List[BenchmarkEntry] = Field(..., description="List of benchmarks in the suite")
+    benchmarks: list[BenchmarkEntry] = Field(..., description="List of benchmarks in the suite")
 
 
 def parse_suite_file(path: str | Path) -> Suite:

--- a/metriq_gym/suite_parser.py
+++ b/metriq_gym/suite_parser.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class BenchmarkEntry(BaseModel):
+    name: str = Field(..., description="Unique name for the benchmark in the suite")
+    config: Dict[str, Any] = Field(..., description="Benchmark configuration dictionary")
+
+
+class Suite(BaseModel):
+    name: str = Field(..., description="Suite name")
+    benchmarks: List[BenchmarkEntry] = Field(..., description="List of benchmarks in the suite")
+
+
+def parse_suite_file(path: str | Path) -> Suite:
+    """Parse a suite JSON file and return a Suite object."""
+    with open(path, "r") as f:
+        data = json.load(f)
+    return Suite.model_validate(data)

--- a/metriq_gym/suites/uf_frugal_3.json
+++ b/metriq_gym/suites/uf_frugal_3.json
@@ -3,6 +3,13 @@
   "description": "Verified Unitary Foundation Suite with the three most frugal benchmarks.",
   "benchmarks": [
     {
+        "name": "BSEQ",
+        "config": {
+            "benchmark_name": "BSEQ",
+            "shots": 1000
+        }
+    },
+    {
         "name": "wormhole_7_qubits",
         "config": {
             "benchmark_name": "Wormhole",
@@ -16,13 +23,6 @@
             "benchmark_name": "QML Kernel",
             "num_qubits": 20,
             "shots": 1024
-        }
-    },
-    {
-        "name": "BSEQ",
-        "config": {
-            "benchmark_name": "BSEQ",
-            "shots": 1000
         }
     }
   ]

--- a/metriq_gym/suites/uf_frugal_3.json
+++ b/metriq_gym/suites/uf_frugal_3.json
@@ -1,6 +1,6 @@
 {
   "name": "verified_uf_suite",
-  "description": "Verified Unitary Foundation Suite withe the three most frugal benchmarks.",
+  "description": "Verified Unitary Foundation Suite with the three most frugal benchmarks.",
   "benchmarks": [
     {
         "name": "wormhole_7_qubits",

--- a/metriq_gym/suites/uf_frugal_3.json
+++ b/metriq_gym/suites/uf_frugal_3.json
@@ -1,0 +1,29 @@
+{
+  "name": "verified_uf_suite",
+  "description": "Verified Unitary Foundation Suite withe the three most frugal benchmarks.",
+  "benchmarks": [
+    {
+        "name": "wormhole_7_qubits",
+        "config": {
+            "benchmark_name": "Wormhole",
+            "num_qubits": 7,
+            "shots": 8192
+        }
+    },
+    {
+        "name": "qml",
+        "config": {
+            "benchmark_name": "QML Kernel",
+            "num_qubits": 20,
+            "shots": 1024
+        }
+    },
+    {
+        "name": "BSEQ",
+        "config": {
+            "benchmark_name": "BSEQ",
+            "shots": 1000
+        }
+    }
+  ]
+}

--- a/tests/e2e/test_dispatch_poll_job.py
+++ b/tests/e2e/test_dispatch_poll_job.py
@@ -11,10 +11,9 @@ def store_env(monkeypatch, tmp_path):
 
 
 @pytest.mark.e2e
-def test_dispatch_and_poll_local_simulator(tmp_path):
+def test_dispatch_and_poll_single_job_on_local_simulator(tmp_path):
     """
-    End-to-end test of the CLI workflow:
-
+    End-to-end test of the CLI workflow for a single job on the local simulator
         1. dispatch   -> returns a Metriq-Gym job_id
         2. poll       -> succeeds immediately for the local simulator
         3. validate   -> JSON result file contains measurement counts
@@ -28,8 +27,8 @@ def test_dispatch_and_poll_local_simulator(tmp_path):
     subprocess.run(
         [
             "mgym",
-            "dispatch",
             "job",
+            "dispatch",
             str(example_cfg),
             "-p",
             "local",
@@ -48,8 +47,8 @@ def test_dispatch_and_poll_local_simulator(tmp_path):
     poll_cmd = subprocess.run(
         [
             "mgym",
-            "poll",
             "job",
+            "poll",
             "latest",
             "--json",
             str(outfile),  # temp file to keep the repo clean
@@ -77,6 +76,7 @@ def test_dispatch_and_poll_local_simulator(tmp_path):
     delete_cmd = subprocess.run(
         [
             "mgym",
+            "job",
             "delete",
             "latest",
         ],

--- a/tests/e2e/test_dispatch_poll_job.py
+++ b/tests/e2e/test_dispatch_poll_job.py
@@ -29,6 +29,7 @@ def test_dispatch_and_poll_local_simulator(tmp_path):
         [
             "mgym",
             "dispatch",
+            "job",
             str(example_cfg),
             "-p",
             "local",
@@ -48,6 +49,7 @@ def test_dispatch_and_poll_local_simulator(tmp_path):
         [
             "mgym",
             "poll",
+            "job",
             "latest",
             "--json",
             str(outfile),  # temp file to keep the repo clean

--- a/tests/e2e/test_dispatch_poll_suite.py
+++ b/tests/e2e/test_dispatch_poll_suite.py
@@ -1,0 +1,73 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def store_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("MGR_LOCAL_JOB_DIR", str(tmp_path))
+
+
+@pytest.mark.e2e
+def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
+    """
+    End-to-end test of the CLI workflow for a suite with two jobs on the local simulator
+        1. dispatch   -> returns a Metriq-Gym suite_id and two job_ids
+        2. poll       -> succeeds immediately for the local simulator
+        3. validate   -> JSON result file contains results for both jobs
+    """
+
+    # ------------------------------------------------------------------
+    # 1. Dispatch a suite with two benchmarks on the local Aer simulator
+    # ------------------------------------------------------------------
+    example_suite_cfg = Path(__file__).parent.resolve() / "test_suite.json"
+
+    dispatch_cmd = subprocess.run(
+        [
+            "mgym",
+            "suite",
+            "dispatch",
+            str(example_suite_cfg),
+            "-p",
+            "local",
+            "-d",
+            "aer_simulator",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Dispatch complete for suite" in dispatch_cmd.stdout
+
+    # Extract suite_id from output (assumes suite_id is printed in stdout)
+    suite_id = None
+    for line in dispatch_cmd.stdout.splitlines():
+        if "Suite ID" in line:
+            suite_id = line.split()[-1].strip(".")
+            break
+    assert suite_id, "Suite ID not found in dispatch output"
+
+    # ------------------------------------------------------------------
+    # 2. Poll the suite
+    # ------------------------------------------------------------------
+    poll_cmd = subprocess.run(
+        ["mgym", "suite", "poll", suite_id],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Suite Results" in poll_cmd.stdout, "Suite results not found in poll output"
+
+    # ------------------------------------------------------
+    # 3. Delete the suite to clean up
+    # ------------------------------------------------------
+    delete_cmd = subprocess.run(
+        ["mgym", "suite", "delete", suite_id],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert f"All jobs for suite ID {suite_id} deleted successfully" in delete_cmd.stdout

--- a/tests/e2e/test_suite.json
+++ b/tests/e2e/test_suite.json
@@ -1,0 +1,21 @@
+{
+  "name": "local_sim_suite",
+  "benchmarks": [
+    {
+      "name": "qml_kernel_4q",
+      "config": {
+        "benchmark_name": "QML Kernel",
+        "num_qubits": 4,
+        "shots": 10
+      }
+    },
+    {
+      "name": "qml_kernel_3q",
+      "config": {
+        "benchmark_name": "QML Kernel",
+        "num_qubits": 3,
+        "shots": 10
+      }
+    }
+  ]
+}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,7 +37,7 @@ def test_list_jobs_all(capsys):
         ),
     ]
 
-    list_jobs(mock_jobs, show_index=False)
+    list_jobs(mock_jobs, show_index=False, show_suite_id=False)
 
     # Capture the output
     captured = capsys.readouterr()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -8,7 +8,6 @@ from metriq_gym.run import (
     dispatch_job,
 )
 from metriq_gym.exceptions import QBraidSetupError
-from metriq_gym.benchmarks.bseq import BSEQData
 
 
 class FakeDevice:
@@ -96,112 +95,11 @@ def test_setup_device_invalid_device(mock_provider, patch_load_provider, caplog)
     assert "Devices available: ['device1', 'device2']" in caplog.text
 
 
-@patch("metriq_gym.run.setup_device")
-@patch("metriq_gym.run.load_and_validate")
-@patch("metriq_gym.run.setup_benchmark")
-@patch("os.path.exists")
-def test_dispatch_multiple_benchmarks_success(
-    mock_exists,
-    mock_setup_benchmark,
-    mock_load_validate,
-    mock_setup_device,
-    mock_args,
-    mock_job_manager,
-    capsys,
-):
-    """Test successful dispatch of multiple benchmark configuration files."""
-    # Setup mocks
-    mock_args.benchmark_configs = ["bseq.json", "clops.json"]
-    mock_exists.return_value = True
-
-    mock_device = MagicMock()
-    mock_setup_device.return_value = mock_device
-
-    # Mock different benchmark params for each file
-    mock_bseq_params = MagicMock()
-    mock_bseq_params.benchmark_name = "BSEQ"
-    mock_bseq_params.model_dump.return_value = {"benchmark_name": "BSEQ", "shots": 1000}
-
-    mock_clops_params = MagicMock()
-    mock_clops_params.benchmark_name = "CLOPS"
-    mock_clops_params.model_dump.return_value = {"benchmark_name": "CLOPS", "width": 4}
-
-    mock_load_validate.side_effect = [mock_bseq_params, mock_clops_params]
-
-    mock_handler = MagicMock()
-    mock_job_data = BSEQData(provider_job_ids=["job1"], shots=1000, num_qubits=5)
-    mock_handler.dispatch_handler.return_value = mock_job_data
-    mock_setup_benchmark.return_value = mock_handler
-
-    # Execute function
-    dispatch_job(mock_args, mock_job_manager)
-
-    # Verify output
-    captured = capsys.readouterr()
-    assert "Starting job dispatch..." in captured.out
-    assert "Successfully dispatched 2/2 benchmarks." in captured.out
-    assert "BSEQ (bseq.json) dispatched with ID:" in captured.out
-    assert "CLOPS (clops.json) dispatched with ID:" in captured.out
-
-    # Verify all benchmarks were processed
-    assert mock_job_manager.add_job.call_count == 2
-
-
-@patch("metriq_gym.run.setup_device")
-@patch("metriq_gym.run.load_and_validate")
-@patch("metriq_gym.run.setup_benchmark")
-@patch("os.path.exists")
-def test_dispatch_duplicate_benchmark_types(
-    mock_exists,
-    mock_setup_benchmark,
-    mock_load_validate,
-    mock_setup_device,
-    mock_args,
-    mock_job_manager,
-    capsys,
-):
-    """Test dispatch of same benchmark type with different configurations."""
-    # Setup mocks for same benchmark type, different configs
-    mock_args.benchmark_configs = ["bseq_config1.json", "bseq_config2.json"]
-    mock_exists.return_value = True
-
-    mock_device = MagicMock()
-    mock_setup_device.return_value = mock_device
-
-    # Mock different BSEQ configurations
-    mock_bseq_params1 = MagicMock()
-    mock_bseq_params1.benchmark_name = "BSEQ"
-    mock_bseq_params1.model_dump.return_value = {"benchmark_name": "BSEQ", "shots": 1000}
-
-    mock_bseq_params2 = MagicMock()
-    mock_bseq_params2.benchmark_name = "BSEQ"
-    mock_bseq_params2.model_dump.return_value = {"benchmark_name": "BSEQ", "shots": 5000}
-
-    mock_load_validate.side_effect = [mock_bseq_params1, mock_bseq_params2]
-
-    mock_handler = MagicMock()
-    mock_job_data = BSEQData(provider_job_ids=["job1"], shots=1000, num_qubits=5)
-    mock_handler.dispatch_handler.return_value = mock_job_data
-    mock_setup_benchmark.return_value = mock_handler
-
-    # Execute function
-    dispatch_job(mock_args, mock_job_manager)
-
-    # Verify output
-    captured = capsys.readouterr()
-    assert "Successfully dispatched 2/2 benchmarks." in captured.out
-    assert "BSEQ (bseq_config1.json) dispatched with ID:" in captured.out
-    assert "BSEQ (bseq_config2.json) dispatched with ID:" in captured.out
-
-    # Verify both jobs were processed
-    assert mock_job_manager.add_job.call_count == 2
-
-
 @patch("os.path.exists")
 def test_dispatch_missing_config_file(mock_exists, mock_args, mock_job_manager, capsys):
     """Test behavior when configuration file is missing."""
     # Setup mocks
-    mock_args.benchmark_configs = ["missing.json", "also_missing.json"]
+    mock_args.benchmark_config = "missing.json"
     mock_exists.return_value = False  # Simulate missing files
 
     # Mock setup_device to avoid provider validation error
@@ -215,42 +113,3 @@ def test_dispatch_missing_config_file(mock_exists, mock_args, mock_job_manager, 
         # Verify output shows file not found errors
         captured = capsys.readouterr()
         assert "Configuration file not found" in captured.out
-        assert "Successfully dispatched 0/2 benchmarks." in captured.out
-
-
-@patch("metriq_gym.run.setup_device")
-@patch("metriq_gym.run.load_and_validate")
-@patch("os.path.exists")
-def test_dispatch_mixed_success_failure(
-    mock_exists, mock_load_validate, mock_setup_device, mock_args, mock_job_manager, capsys
-):
-    """Test dispatch with mix of successful and failed configurations."""
-    # Setup mocks
-    mock_args.benchmark_configs = ["good.json", "bad.json"]
-    mock_exists.return_value = True
-
-    mock_device = MagicMock()
-    mock_setup_device.return_value = mock_device
-
-    # First file succeeds, second fails
-    mock_good_params = MagicMock()
-    mock_good_params.benchmark_name = "BSEQ"
-    mock_good_params.model_dump.return_value = {"benchmark_name": "BSEQ"}
-
-    mock_load_validate.side_effect = [mock_good_params, ValueError("Invalid configuration")]
-
-    # Mock successful benchmark setup for first file
-    with patch("metriq_gym.run.setup_benchmark") as mock_setup_benchmark:
-        mock_handler = MagicMock()
-        mock_job_data = BSEQData(provider_job_ids=["job1"], shots=1000, num_qubits=5)
-        mock_handler.dispatch_handler.return_value = mock_job_data
-        mock_setup_benchmark.return_value = mock_handler
-
-        # Execute function
-        dispatch_job(mock_args, mock_job_manager)
-
-        # Verify output shows mixed results
-        captured = capsys.readouterr()
-        assert "Successfully dispatched 1/2 benchmarks." in captured.out
-        assert "BSEQ (good.json) dispatched with ID:" in captured.out
-        assert "bad.json failed: ValueError: Invalid configuration" in captured.out

--- a/tests/unit/test_suite_parser.py
+++ b/tests/unit/test_suite_parser.py
@@ -1,0 +1,64 @@
+import pytest
+import json
+from pathlib import Path
+from metriq_gym.suite_parser import BenchmarkEntry, Suite, parse_suite_file
+
+
+def test_benchmark_entry_model():
+    entry = BenchmarkEntry(name="test_benchmark", config={"param": 1})
+    assert entry.name == "test_benchmark"
+    assert entry.config == {"param": 1}
+
+
+def test_suite_model():
+    entry1 = BenchmarkEntry(name="b1", config={"a": 1})
+    entry2 = BenchmarkEntry(name="b2", config={"b": 2})
+    suite = Suite(name="suite1", benchmarks=[entry1, entry2])
+    assert suite.name == "suite1"
+    assert len(suite.benchmarks) == 2
+    assert suite.benchmarks[0].name == "b1"
+    assert suite.benchmarks[1].config == {"b": 2}
+
+
+def test_parse_suite_file(tmp_path):
+    suite_data = {
+        "name": "suite_test",
+        "benchmarks": [
+            {"name": "bench1", "config": {"x": 10}},
+            {"name": "bench2", "config": {"y": 20}},
+        ],
+    }
+    suite_file = tmp_path / "suite.json"
+    suite_file.write_text(json.dumps(suite_data))
+    suite = parse_suite_file(suite_file)
+    assert suite.name == "suite_test"
+    assert len(suite.benchmarks) == 2
+    assert suite.benchmarks[0].name == "bench1"
+    assert suite.benchmarks[1].config == {"y": 20}
+
+
+def test_parse_suite_file_with_path_object(tmp_path):
+    suite_data = {
+        "name": "suite_path",
+        "benchmarks": [{"name": "benchA", "config": {"foo": "bar"}}],
+    }
+    suite_file = tmp_path / "suite_path.json"
+    suite_file.write_text(json.dumps(suite_data))
+    suite = parse_suite_file(Path(suite_file))
+    assert suite.name == "suite_path"
+    assert suite.benchmarks[0].name == "benchA"
+
+
+def test_parse_suite_file_invalid_json(tmp_path):
+    suite_file = tmp_path / "invalid.json"
+    suite_file.write_text("{invalid json}")
+    with pytest.raises(json.JSONDecodeError):
+        parse_suite_file(suite_file)
+
+
+def test_parse_suite_file_invalid_schema(tmp_path):
+    suite_data = {"invalid": "data"}
+    suite_file = tmp_path / "invalid_schema.json"
+    suite_file.write_text(json.dumps(suite_data))
+    with pytest.raises(Exception):
+        parse_suite_file(suite_file)


### PR DESCRIPTION
# Description

Introduces support for managing and dispatching suites of benchmarks, including a new CLI subaction (`suite`) for all the existing actions (`dispatch`, `poll`, `view`) 

Note: this also deprecates the functionality to dispatched multiple benchmark jobs in one command, because that's now subsumed by dispatching a suite.

*CLI change*
The CLI command requires that the resource (`job` or `suite`) is specified, that is, instead of `mgym dispatch` it's now `mgym job dispatch` or `mgym suite dispatch`

# Issue ticket number and link

Fixes #416 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

TODO: specific tests for suite implementation to be added

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
