### PR TITLE
feat: adding dynamic versioning

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: github.event.release.prerelease == false
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0  # fetch full history and tags for versioning
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -29,6 +29,9 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Enable Poetry dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          fetch-depth: 0  # fetch full history and tags for versioning
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -29,6 +29,9 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Enable Poetry dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
+
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: github.event.release.prerelease == true
     name: Build and publish Python distributions to TestPyPI
     runs-on: ubuntu-latest
     environment: testpypi

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ eval $(poetry env activate)
 ```
 All Python commands below should be run in the virtual environment.
 
+## Release Process
+
+Releases use dynamic versioning derived from Git tags via a Poetry plugin; do not edit `version` in `pyproject.toml`.
+
+- Tag a release (SemVer):
+  - Stable: `git tag -a vX.Y.Z -m "Release X.Y.Z" && git push origin vX.Y.Z`
+  - Pre-release: `git tag -a vX.Y.Z-rc.1 -m "Pre-release X.Y.Z-rc.1" && git push origin vX.Y.Z-rc.1`
+- Create a GitHub Release from the tag:
+  - Check “This is a pre-release” for RC/beta tags.
+- CI behavior:
+  - Pre-releases publish to TestPyPI only.
+  - Regular releases publish to PyPI.
+- Version resolution: tags like `v1.2.3-rc.1` become PEP 440 `1.2.3rc1` in built artifacts.
+
 ## Workflow
 
 metriq-gym supports two type of resources: benchmarks and suites of benchmarks.

--- a/README.md
+++ b/README.md
@@ -111,20 +111,6 @@ eval $(poetry env activate)
 ```
 All Python commands below should be run in the virtual environment.
 
-## Release Process
-
-Releases use dynamic versioning derived from Git tags via a Poetry plugin; do not edit `version` in `pyproject.toml`.
-
-- Tag a release (SemVer):
-  - Stable: `git tag -a vX.Y.Z -m "Release X.Y.Z" && git push origin vX.Y.Z`
-  - Pre-release: `git tag -a vX.Y.Z-rc.1 -m "Pre-release X.Y.Z-rc.1" && git push origin vX.Y.Z-rc.1`
-- Create a GitHub Release from the tag:
-  - Check “This is a pre-release” for RC/beta tags.
-- CI behavior:
-  - Pre-releases publish to TestPyPI only.
-  - Regular releases publish to PyPI.
-- Version resolution: tags like `v1.2.3-rc.1` become PEP 440 `1.2.3rc1` in built artifacts.
-
 ## Workflow
 
 metriq-gym supports two type of resources: benchmarks and suites of benchmarks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ enable = true
 vcs = "git"
 style = "pep440"
 # Expect tags like v1.2.3 or 1.2.3; uses latest tag for release builds.
+metadata = true
 
 [project.entry-points."qbraid.providers"]
 local = "metriq_gym.local.provider:LocalProvider"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 ]
 readme = "README.md"
 license = { text = "Apache-2.0" }
-version = "0.2.1-dev"
+version = "0.0.0"  # managed by poetry-dynamic-versioning
 requires-python = ">=3.12"
 
 [project.scripts]
@@ -88,6 +88,12 @@ markers = [
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "pep440"
+# Expect tags like v1.2.3 or 1.2.3; uses latest tag for release builds.
 
 [project.entry-points."qbraid.providers"]
 local = "metriq_gym.local.provider:LocalProvider"


### PR DESCRIPTION
**Summary**
- Switches package versioning to be derived from Git tags at build time.
- Routes GitHub Release prereleases to TestPyPI and finals to PyPI.
- Documents the release process with tagging examples.

**Changes**
- pyproject.toml:
  - Set `version = "0.0.0"` (managed by plugin).
  - Added `[tool.poetry-dynamic-versioning]` with `enable = true`, `vcs = "git"`
, `style = "pep440"`.
- Workflows:
  - `.github/workflows/publish-to-testpypi.yml`: install plugin; publish only wh
en `release.prerelease == true`.
  - `.github/workflows/publish-to-pypi.yml`: install plugin; publish only when `
release.prerelease == false`.
- README:
  - New “Release Process” section with SemVer tagging commands and CI routing.

**Rationale**
- Removes manual `pyproject.toml` version bumps.
on targets.

**CI Behavior**
- Pre-releases (e.g., `v1.2.3-rc.1`) → TestPyPI.
- Final releases (e.g., `v1.2.3`) → PyPI.
- Plugin: `poetry-dynamic-versioning[plugin]` installed before build; converts t
ags to PEP 440 (`v1.2.3-rc.1` → `1.2.3rc1`).

**Release Workflow**
- Stable: `git tag -a vX.Y.Z -m "Release X.Y.Z" && git push origin vX.Y.Z`
- Pre-release: `git tag -a vX.Y.Z-rc.1 -m "Pre-release X.Y.Z-rc.1" && git push o
rigin vX.Y.Z-rc.1`
- Create a GitHub Release from the tag; check “pre-release” for RCs.

**How to Test**
- Create a prerelease GitHub Release (e.g., `v0.3.0-rc.1`) and confirm TestPyPI
publish.
- Create a final GitHub Release (e.g., `v0.3.0`) and confirm PyPI publish.
- Local build (optional): `poetry self add "poetry-dynamic-versioning[plugin]" &
& poetry build` to verify resolved version.