### PR TITLE
Fix averaging in mirror circuit benchmark

### DIFF
--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -46,7 +46,7 @@ class MirrorCircuitsData(BenchmarkData):
     expected_bitstrings: list[str]
 
 
-SUCCESS_PROBABILITY_THRESHOLD = 2.0 / 3.0
+SUCCESS_PROBABILITY_THRESHOLD = 1 / np.e
 
 
 def select_optimal_qubit_subset(topology_graph: rx.PyGraph, target_width: int) -> list[int]:

--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -59,7 +59,7 @@ def _(device: AzureQuantumDevice) -> rx.PyGraph:
 
 @connectivity_graph.register
 def _(device: LocalAerDevice) -> rx.PyGraph:
-    coupling_map = device._backend.configuration().coupling_map
-    if coupling_map is None:
+    coupling_list = device._backend.configuration().coupling_map
+    if coupling_list is None:
         return rx.generators.complete_graph(device._backend.configuration().n_qubits)
-    return coupling_map_to_graph(coupling_map)
+    return coupling_map_to_graph(CouplingMap(coupling_list))

--- a/metriq_gym/registry.py
+++ b/metriq_gym/registry.py
@@ -1,7 +1,13 @@
 from .constants import JobType
 
-from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData
-from metriq_gym.benchmarks.qml_kernel import QMLKernel, QMLKernelData
+from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
+from metriq_gym.benchmarks.qml_kernel import QMLKernel, QMLKernelData, QMLKernelResult
+from metriq_gym.benchmarks.bseq import BSEQResult
+from metriq_gym.benchmarks.clops import ClopsResult
+from metriq_gym.benchmarks.quantum_volume import QuantumVolumeResult
+from metriq_gym.benchmarks.mirror_circuits import MirrorCircuitsResult
+from metriq_gym.benchmarks.wormhole import WormholeResult
+from metriq_gym.benchmarks.qedc_benchmarks import QEDCResult
 from metriq_gym.benchmarks.clops import Clops, ClopsData
 from metriq_gym.benchmarks.quantum_volume import QuantumVolume, QuantumVolumeData
 from metriq_gym.benchmarks.bseq import BSEQ, BSEQData
@@ -33,6 +39,19 @@ BENCHMARK_DATA_CLASSES: dict[JobType, type[BenchmarkData]] = {
     JobType.PHASE_ESTIMATION: QEDCData,
     JobType.HIDDEN_SHIFT: QEDCData,
     JobType.QUANTUM_FOURIER_TRANSFORM: QEDCData,
+}
+
+BENCHMARK_RESULT_CLASSES: dict[JobType, type[BenchmarkResult]] = {
+    JobType.BSEQ: BSEQResult,
+    JobType.CLOPS: ClopsResult,
+    JobType.QML_KERNEL: QMLKernelResult,
+    JobType.QUANTUM_VOLUME: QuantumVolumeResult,
+    JobType.MIRROR_CIRCUITS: MirrorCircuitsResult,
+    JobType.WORMHOLE: WormholeResult,
+    JobType.BERNSTEIN_VAZIRANI: QEDCResult,
+    JobType.PHASE_ESTIMATION: QEDCResult,
+    JobType.HIDDEN_SHIFT: QEDCResult,
+    JobType.QUANTUM_FOURIER_TRANSFORM: QEDCResult,
 }
 
 SCHEMA_MAPPING = {

--- a/metriq_gym/registry.py
+++ b/metriq_gym/registry.py
@@ -2,18 +2,20 @@ from .constants import JobType
 
 from metriq_gym.benchmarks.benchmark import Benchmark, BenchmarkData, BenchmarkResult
 from metriq_gym.benchmarks.qml_kernel import QMLKernel, QMLKernelData, QMLKernelResult
-from metriq_gym.benchmarks.bseq import BSEQResult
-from metriq_gym.benchmarks.clops import ClopsResult
-from metriq_gym.benchmarks.quantum_volume import QuantumVolumeResult
-from metriq_gym.benchmarks.mirror_circuits import MirrorCircuitsResult
-from metriq_gym.benchmarks.wormhole import WormholeResult
-from metriq_gym.benchmarks.qedc_benchmarks import QEDCResult
-from metriq_gym.benchmarks.clops import Clops, ClopsData
-from metriq_gym.benchmarks.quantum_volume import QuantumVolume, QuantumVolumeData
-from metriq_gym.benchmarks.bseq import BSEQ, BSEQData
-from metriq_gym.benchmarks.mirror_circuits import MirrorCircuits, MirrorCircuitsData
-from metriq_gym.benchmarks.wormhole import Wormhole, WormholeData
-from metriq_gym.benchmarks.qedc_benchmarks import QEDCBenchmark, QEDCData
+from metriq_gym.benchmarks.clops import Clops, ClopsData, ClopsResult
+from metriq_gym.benchmarks.quantum_volume import (
+    QuantumVolume,
+    QuantumVolumeData,
+    QuantumVolumeResult,
+)
+from metriq_gym.benchmarks.bseq import BSEQ, BSEQData, BSEQResult
+from metriq_gym.benchmarks.mirror_circuits import (
+    MirrorCircuits,
+    MirrorCircuitsData,
+    MirrorCircuitsResult,
+)
+from metriq_gym.benchmarks.wormhole import Wormhole, WormholeData, WormholeResult
+from metriq_gym.benchmarks.qedc_benchmarks import QEDCBenchmark, QEDCData, QEDCResult
 
 BENCHMARK_HANDLERS: dict[JobType, type[Benchmark]] = {
     JobType.BSEQ: BSEQ,

--- a/metriq_gym/schemas/examples/mirror_circuits.example.json
+++ b/metriq_gym/schemas/examples/mirror_circuits.example.json
@@ -1,7 +1,8 @@
 {
   "benchmark_name": "Mirror Circuits",
+  "width": 4,
   "num_layers": 1,          
   "two_qubit_gate_prob": 0.1,  
   "shots": 1000,
-  "num_circuits": 5
+  "num_circuits": 2
 }

--- a/tests/unit/benchmarks/test_mirror_circuits.py
+++ b/tests/unit/benchmarks/test_mirror_circuits.py
@@ -331,14 +331,15 @@ class TestMirrorCircuitsBenchmark:
 
         result = benchmark.dispatch_handler(mock_device)
 
+        NUM_CIRCUITS = 5
         assert isinstance(result, MirrorCircuitsData)
         assert result.num_layers == 2
         assert result.two_qubit_gate_prob == 0.5
         assert result.two_qubit_gate_name == "CNOT"
         assert result.shots == 100
-        assert result.num_circuits == 5
+        assert result.num_circuits == NUM_CIRCUITS
         assert result.seed == 42
-        assert result.expected_bitstring == "001"  # From our mock
+        assert result.expected_bitstrings == ["001"] * NUM_CIRCUITS
         assert result.provider_job_ids == ["test_job_id"]
 
         # Verify that generate_mirror_circuit was called correctly
@@ -388,11 +389,11 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=2,
             num_circuits=2,
             seed=42,
-            expected_bitstring="01",
+            expected_bitstrings=["01"],
         )
 
         # Mock perfect results (all measurements return expected bitstring)
-        counts1 = MeasCount({"01": 100})  # Matches expected_bitstring
+        counts1 = MeasCount({"01": 100})  # Matches expected_bitstrings
         counts2 = MeasCount({"01": 100})
         result_data = [GateModelResultData(measurement_counts=[counts1, counts2])]
         quantum_jobs = [MagicMock()]
@@ -416,7 +417,7 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=2,
             num_circuits=1,
             seed=42,
-            expected_bitstring="11",
+            expected_bitstrings=["11"],
         )
 
         # Mock partial success (70% success rate for "11")
@@ -445,7 +446,7 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=2,
             num_circuits=1,
             seed=42,
-            expected_bitstring="10",
+            expected_bitstrings=["10"],
         )
 
         # Mock low success (50% success rate for "10", below 2/3 threshold)
@@ -469,7 +470,7 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=0,
             num_circuits=1,
             seed=42,
-            expected_bitstring="",
+            expected_bitstrings=["01"],
         )
 
         result_data = []
@@ -488,7 +489,7 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=2,
             num_circuits=2,
             seed=42,
-            expected_bitstring="01",
+            expected_bitstrings=["01", "01"],
         )
 
         # Mock results from two circuits - both looking for "01"

--- a/tests/unit/benchmarks/test_mirror_circuits.py
+++ b/tests/unit/benchmarks/test_mirror_circuits.py
@@ -470,7 +470,7 @@ class TestMirrorCircuitsBenchmark:
             num_qubits=0,
             num_circuits=1,
             seed=42,
-            expected_bitstrings=["01"],
+            expected_bitstrings=[""],
         )
 
         result_data = []

--- a/tests/unit/benchmarks/test_mirror_circuits.py
+++ b/tests/unit/benchmarks/test_mirror_circuits.py
@@ -449,16 +449,16 @@ class TestMirrorCircuitsBenchmark:
             expected_bitstrings=["10"],
         )
 
-        # Mock low success (50% success rate for "10", below 2/3 threshold)
-        counts = MeasCount({"10": 50, "01": 20, "11": 20, "00": 10})
+        # Mock low success (10% success rate for "10", below 1/e threshold)
+        counts = MeasCount({"10": 10, "01": 30, "11": 30, "00": 30})
         result_data = [GateModelResultData(measurement_counts=counts)]
         quantum_jobs = [MagicMock()]
 
         result = benchmark.poll_handler(job_data, result_data, quantum_jobs)
 
         assert isinstance(result, MirrorCircuitsResult)
-        assert result.success_probability == 0.5
-        assert result.binary_success is False  # 0.5 < 2/3
+        assert result.success_probability == 0.1
+        assert result.binary_success is False  # 0.1 < 1/e
 
     def test_poll_handler_zero_qubits_error(self, benchmark):
         job_data = MirrorCircuitsData(


### PR DESCRIPTION
# Description

Addresses issue with Mirror Circuit benchmarks spotted by @Changhao-Li while trying to fetch results from hardware.

The expected bitstring against which the final result was checked happened to be the same for all the circuits, in case of protocol running with multiple random circuits.

Bonus:
- Fixes an issue with parsing the coupling map of IBM *fake* backends
- Fixes an issue with storing results introduced in #487

# Issue ticket number and link

Fixes https://github.com/unitaryfoundation/metriq-gym-data/issues/2

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

It breaks polling of mirror circuits benchmark dispatched prior to this PR, which were not valid anyway.

# How Has This Been Tested?

Smoke testing against fake backends and real hardware + unit/e2e suite

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
