### PR TITLE
Modify mirror circuit parameters

### DIFF
--- a/metriq_gym/benchmarks/mirror_circuits.py
+++ b/metriq_gym/benchmarks/mirror_circuits.py
@@ -46,7 +46,7 @@ class MirrorCircuitsData(BenchmarkData):
     expected_bitstrings: list[str]
 
 
-SUCCESS_PROBABILITY_THRESHOLD = 1 / np.e
+POLARIZATION_THRESHOLD = 1 / np.e
 
 
 def select_optimal_qubit_subset(topology_graph: rx.PyGraph, target_width: int) -> list[int]:
@@ -480,5 +480,5 @@ class MirrorCircuits(Benchmark):
         return MirrorCircuitsResult(
             success_probability=final_success_probability,
             polarization=polarization,
-            binary_success=bool(final_success_probability >= SUCCESS_PROBABILITY_THRESHOLD),
+            binary_success=bool(polarization >= POLARIZATION_THRESHOLD),
         )

--- a/metriq_gym/schemas/mirror_circuits.schema.json
+++ b/metriq_gym/schemas/mirror_circuits.schema.json
@@ -21,7 +21,7 @@
       "description": "The number of random Clifford layers in the mirror circuit. This controls the circuit depth.",
       "default": 3,
       "minimum": 1,
-      "maximum": 50,
+      "maximum": 500,
       "examples": [3, 5, 10]
     },
     "two_qubit_gate_prob": {


### PR DESCRIPTION
# Description

1. Modified the `binary_success` variable so now the calculation matches with the original paper. We should use `polarization` to get the binary variable instead of `success_probability`;
2. Changed the max value of `num_layers` from 50 to 500 to enable large-scale simulations/experiment.s


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (or not applicable)
