### PR TITLE
Dynamic version in local dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Metriq
 .metriq_gym_jobs.jsonl
+metriq_gym/_version.py
 
 # Sphinx
 _build

--- a/metriq_gym/__init__.py
+++ b/metriq_gym/__init__.py
@@ -1,0 +1,3 @@
+from ._version import __version__
+
+__all__ = ["__version__"]

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -1,6 +1,6 @@
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime
-import importlib.metadata
+from metriq_gym._version import __version__
 import json
 import os
 import pprint
@@ -25,9 +25,7 @@ class MetriqGymJob:
     device_name: str
     dispatch_time: datetime
     suite_id: str | None = None
-    app_version: str | None = field(
-        default_factory=lambda: importlib.metadata.version("metriq-gym")
-    )
+    app_version: str | None = __version__
     result_data: dict[str, Any] | None = None
 
     def to_table_row(self, show_suite_id: bool) -> list[str | None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ style = "pep440"
 # Expect tags like v1.2.3 or 1.2.3; uses latest tag for release builds.
 metadata = false
 
+[tool.poetry-dynamic-versioning.files."metriq_gym/_version.py"]
+persistent-substitution = true
+initial-content = """
+__version__ = \"0.0.0\"
+"""
+
 [project.entry-points."qbraid.providers"]
 local = "metriq_gym.local.provider:LocalProvider"
 

--- a/tests/unit/test_job_manager.py
+++ b/tests/unit/test_job_manager.py
@@ -183,13 +183,12 @@ def test_delete_job(job_manager, sample_job):
     assert len(jobs) == 0
 
 
-def test_job_app_version_serialization_and_export(monkeypatch):
+def test_job_app_version_serialization_and_export():
     """Ensure stored version persists across serialization and is used by exporters."""
-    import importlib.metadata
     from metriq_gym.exporters.json_exporter import JsonExporter
     from metriq_gym.benchmarks.benchmark import BenchmarkResult
+    from metriq_gym import __version__ as expected_version
 
-    monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.0")
     job = MetriqGymJob(
         id="ver_job",
         provider_name="provider",
@@ -200,16 +199,15 @@ def test_job_app_version_serialization_and_export(monkeypatch):
         dispatch_time=datetime.now(),
     )
 
-    assert job.app_version == "1.0"
+    assert job.app_version == expected_version
     serialized = job.serialize()
 
-    monkeypatch.setattr(importlib.metadata, "version", lambda _: "2.0")
     loaded_job = MetriqGymJob.deserialize(serialized)
-    assert loaded_job.app_version == "1.0"
+    assert loaded_job.app_version == expected_version
 
     exporter = JsonExporter(loaded_job, BenchmarkResult())
     export_dict = exporter.as_dict()
-    assert export_dict["app_version"] == "1.0"
+    assert export_dict["app_version"] == expected_version
 
 
 def test_update_job_success(job_manager, sample_job):


### PR DESCRIPTION
# Description

Fixes version handling so that metriq-gym reports the correct Git-derived version both when installed from PyPI and when run directly from a git clone. Previously, the package version defaulted to 0.0.0 when used directly from a Git clone.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested dispatching a local job and now getting
```
│ app_version      │ 0.3.1.post5.dev0 
```
which is what we want

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
