### PR TITLE
Support Braket devices with all-to-all connectivity in BSEQ benchmark

### DIFF
--- a/metriq_gym/qplatform/device.py
+++ b/metriq_gym/qplatform/device.py
@@ -46,9 +46,23 @@ def _(device: QiskitBackend) -> rx.PyGraph:
 
 @connectivity_graph.register
 def _(device: BraketDevice) -> rx.PyGraph:
+    def create_all_to_all_digraph(n_nodes):
+        graph = nx.DiGraph()
+        graph.add_nodes_from(range(n_nodes))
+        for i in range(n_nodes):
+            for j in range(n_nodes):
+                if i != j:
+                    graph.add_edge(i, j)
+        return graph
+
+    if device._provider_name in ["Amazon Braket", "IonQ"]:
+        device_topology = create_all_to_all_digraph(device.num_qubits)
+    else:
+        device_topology = device._device.topology_graph
+
     return cast(
         rx.PyGraph,
-        rx.networkx_converter(nx.Graph(device._device.topology_graph.to_undirected())),
+        rx.networkx_converter(nx.Graph(device_topology.to_undirected())),
     )
 
 

--- a/tests/unit/qplatform/test_device.py
+++ b/tests/unit/qplatform/test_device.py
@@ -59,6 +59,8 @@ def mock_braket_device():
     mock_internal_device = Mock()
     mock_internal_device.topology_graph = MockTopologyGraph(num_qubits=8)
     device._device = mock_internal_device
+    device._provider_name = "Rigetti"
+    device.num_qubits = 8
     return device
 
 
@@ -115,6 +117,32 @@ class TestConnectivityGraphFunction:
         assert result.num_nodes() == 8
         assert result.num_edges() == 8
         mock_braket_device._device.topology_graph.to_undirected.assert_called_once()
+
+    def test_braket_device_all_to_all_connectivity_amazon_braket(self):
+        mock_num_qubits = 4
+        device = Mock(spec=BraketDevice)
+        device._provider_name = "Amazon Braket"
+        device.num_qubits = mock_num_qubits
+
+        result = connectivity_graph(device)
+        assert isinstance(result, rx.PyGraph)
+        assert result.num_nodes() == mock_num_qubits
+        # All-to-all connectivity: n*(n-1)/2 edges
+        expected_edges = mock_num_qubits * (mock_num_qubits - 1) // 2
+        assert result.num_edges() == expected_edges
+
+    def test_braket_device_all_to_all_connectivity_ionq(self):
+        mock_num_qubits = 3
+        device = Mock(spec=BraketDevice)
+        device._provider_name = "IonQ"
+        device.num_qubits = mock_num_qubits
+
+        result = connectivity_graph(device)
+        assert isinstance(result, rx.PyGraph)
+        assert result.num_nodes() == mock_num_qubits
+        # All-to-all connectivity: n*(n-1)/2 edges
+        expected_edges = mock_num_qubits * (mock_num_qubits - 1) // 2
+        assert result.num_edges() == expected_edges
 
     def test_azure_device_connectivity(self, mock_azure_device):
         result = connectivity_graph(mock_azure_device)
@@ -205,6 +233,8 @@ class TestEdgeCases:
         topology.to_undirected = Mock(return_value=nx.Graph())
         mock_internal_device.topology_graph = topology
         device._device = mock_internal_device
+        device._provider_name = "AWS"  # Default to non-all-to-all provider
+        device.num_qubits = 0
 
         result = connectivity_graph(device)
         assert isinstance(result, rx.PyGraph)


### PR DESCRIPTION
# Description
Properly handle all-to-all connected quantum devices from Amazon Braket and IonQ providers. The change adds logic in the `connectivity_graph` function for `BraketDevice` that detects when the provider is "Amazon Braket" or "IonQ" and generates a complete all-to-all connectivity graph.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
poetry run pre-commit install
poetry run pytest -m "not e2e"
poetry run mypy
```
All checks passed.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
