### PR TITLE
Upload results as a PR to GitHub data repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,21 @@ IONQ_API_KEY="<IONQ_API_KEY>"
 # qBraid
 # Obtained at: https://account.qbraid.com/
 QBRAID_API_KEY="<QBRAID_API_KEY>"
+
+# GitHub upload (mgym job upload)
+# Repository to open PRs against, format: owner/repo (default: unitaryfoundation/metriq-data)
+MGYM_UPLOAD_REPO="unitaryfoundation/metriq-data"
+# Base branch for PRs (default: main)
+MGYM_UPLOAD_BASE_BRANCH="main"
+# Directory in the repo to place the JSON file (optional).
+# If unset, mgym uses: results/v<major.minor> (e.g., results/v0.3)
+MGYM_UPLOAD_DIR=""
+# Optional working directory for clones
+MGYM_UPLOAD_CLONE_DIR="<PATH>"
+# GitHub token used to push and create PRs
+# Create a Personal Access Token (classic) with repo scope, or a fine-grained token.
+# Fine-grained token tips: set Resource owner to your account; grant access to All repositories (or ensure future forks are covered),
+# and grant repository permissions: Contents (Read and write) and Pull requests (Read and write).
+# Docs: https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+# Token settings: https://github.com/settings/tokens
+GITHUB_TOKEN="<GITHUB_TOKEN>"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,28 @@ You can poll the suite results using the `suite poll` action:
 mgym suite poll <METRIQ_GYM_SUITE_ID>
 ```
 
+### Upload results to GitHub
+
+Upload benchmark results to unitaryfoundation/metriq-data via a pull request.
+
+Commands
+
+```sh
+# Single job
+mgym job upload <METRIQ_GYM_JOB_ID>
+
+# Whole suite
+mgym suite upload <METRIQ_GYM_SUITE_ID>
+```
+
+Defaults
+- Target repo: unitaryfoundation/metriq-data (override with `--repo` or `MGYM_UPLOAD_REPO`)
+- Directory: metriq-gym/v<major.minor>/<provider> (override with `--dir` or `MGYM_UPLOAD_DIR`)
+- Uploads append records to `results.json` as a pretty-printed JSON array
+
+Auth
+- Set `GITHUB_TOKEN` (or `GH_TOKEN`). If you're an external contributor, fork the metriq-data repo first; mgym pushes to your fork and opens a PR, or prints a compare link if PR creation isn't permitted.
+- Token docs: https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
 ### Credential management
 

--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 
 from tabulate import tabulate
 
@@ -171,8 +172,11 @@ def parse_arguments() -> argparse.Namespace:
     job_poll = job_subparsers.add_parser("poll", help="Poll job")
     job_view = job_subparsers.add_parser("view", help="View job")
     job_delete = job_subparsers.add_parser("delete", help="Delete job")
+    job_upload = job_subparsers.add_parser(
+        "upload", help="Upload job result to a GitHub repo (opens a PR)"
+    )
 
-    for subparser in [job_poll, job_view, job_delete]:
+    for subparser in [job_poll, job_view, job_delete, job_upload]:
         subparser.add_argument(
             JOB_ID_ARGUMENT_NAME, type=str, nargs="?", help="Job ID to operate on (optional)"
         )
@@ -183,6 +187,139 @@ def parse_arguments() -> argparse.Namespace:
         required=False,
         default=argparse.SUPPRESS,
         help="Export results to JSON file (optional)",
+    )
+
+    job_upload.add_argument(
+        "--repo",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_REPO", "unitaryfoundation/metriq-data"),
+        help=(
+            "Target GitHub repo in the form 'owner/repo' "
+            "(env: MGYM_UPLOAD_REPO, default: unitaryfoundation/metriq-data)"
+        ),
+    )
+    job_upload.add_argument(
+        "--base",
+        dest="base_branch",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_BASE_BRANCH", "main"),
+        help="Base branch for the PR (env: MGYM_UPLOAD_BASE_BRANCH, default: main)",
+    )
+    job_upload.add_argument(
+        "--dir",
+        dest="upload_dir",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_DIR"),
+        help=(
+            "Directory in the repo to place the JSON file "
+            "(env: MGYM_UPLOAD_DIR; default: metriq-gym/v<major.minor>/<provider>)"
+        ),
+    )
+    job_upload.add_argument(
+        "--branch",
+        dest="branch_name",
+        type=str,
+        default=None,
+        help="Branch name to create for the PR (default: mgym/upload-<job_id>)",
+    )
+    job_upload.add_argument(
+        "--title",
+        dest="pr_title",
+        type=str,
+        default=None,
+        help="Pull request title (default: includes job id)",
+    )
+    job_upload.add_argument(
+        "--body",
+        dest="pr_body",
+        type=str,
+        default=None,
+        help="Pull request body",
+    )
+    job_upload.add_argument(
+        "--commit-message",
+        dest="commit_message",
+        type=str,
+        default=None,
+        help="Commit message (default: includes job id)",
+    )
+    job_upload.add_argument(
+        "--clone-dir",
+        dest="clone_dir",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_CLONE_DIR"),
+        help="Optional working dir to clone into (env: MGYM_UPLOAD_CLONE_DIR)",
+    )
+
+    suite_upload = suite_subparsers.add_parser(
+        "upload", help="Upload suite results to GitHub (opens a PR or compare link)"
+    )
+    suite_upload.add_argument(
+        "suite_id",
+        type=str,
+        nargs="?",
+        help="Suite ID to upload",
+    )
+    suite_upload.add_argument(
+        "--repo",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_REPO", "unitaryfoundation/metriq-data"),
+        help=(
+            "Target GitHub repo in the form 'owner/repo' "
+            "(env: MGYM_UPLOAD_REPO, default: unitaryfoundation/metriq-data)"
+        ),
+    )
+    suite_upload.add_argument(
+        "--base",
+        dest="base_branch",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_BASE_BRANCH", "main"),
+        help="Base branch for the PR (env: MGYM_UPLOAD_BASE_BRANCH, default: main)",
+    )
+    suite_upload.add_argument(
+        "--dir",
+        dest="upload_dir",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_DIR"),
+        help=(
+            "Directory in the repo to place the JSON file "
+            "(env: MGYM_UPLOAD_DIR; default: metriq-gym/v<major.minor>/<provider>)"
+        ),
+    )
+    suite_upload.add_argument(
+        "--branch",
+        dest="branch_name",
+        type=str,
+        default=None,
+        help="Branch name to create for the PR (default: mgym/upload-<job_id>)",
+    )
+    suite_upload.add_argument(
+        "--title",
+        dest="pr_title",
+        type=str,
+        default=None,
+        help="Pull request title (optional)",
+    )
+    suite_upload.add_argument(
+        "--body",
+        dest="pr_body",
+        type=str,
+        default=None,
+        help="Pull request body",
+    )
+    suite_upload.add_argument(
+        "--commit-message",
+        dest="commit_message",
+        type=str,
+        default=None,
+        help="Commit message (optional)",
+    )
+    suite_upload.add_argument(
+        "--clone-dir",
+        dest="clone_dir",
+        type=str,
+        default=os.environ.get("MGYM_UPLOAD_CLONE_DIR"),
+        help="Optional working dir to clone into (env: MGYM_UPLOAD_CLONE_DIR)",
     )
 
     return parser.parse_args()

--- a/metriq_gym/exporters/github_pr_exporter.py
+++ b/metriq_gym/exporters/github_pr_exporter.py
@@ -1,0 +1,356 @@
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.request
+import urllib.error
+from typing import Optional, Any
+
+from metriq_gym.exporters.base_exporter import BaseExporter
+
+
+class GitHubPRExporter(BaseExporter):
+    """
+    Export job results as a JSON file to a GitHub repository by opening a Pull Request.
+
+    Auth is provided via a GitHub token in the environment (e.g., GITHUB_TOKEN).
+    The exporter clones the target repo, creates a branch, writes the JSON file,
+    commits, pushes, and then opens a PR via the GitHub REST API.
+    """
+
+    def export(
+        self,
+        *,
+        repo: str,
+        base_branch: str = "main",
+        directory: str = "",
+        branch_name: Optional[str] = None,
+        token: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        pr_title: Optional[str] = None,
+        pr_body: Optional[str] = None,
+        clone_dir: Optional[str] = None,
+        payload: dict[str, Any] | list[dict[str, Any]] | None = None,
+        filename: Optional[str] = None,
+        append: bool = False,
+    ) -> str:
+        """
+        Create a PR adding a JSON result file.
+
+        Args:
+            repo: "owner/repo" string.
+            base_branch: Base branch to target for the PR.
+            directory: Directory inside the repo to place the file.
+            branch_name: Branch to create for the changes. Defaults to "mgym/upload-<job_id>".
+            token: GitHub token. If None, read from GITHUB_TOKEN.
+            committer_name: Optional git commit author name.
+            committer_email: Optional git commit author email.
+            commit_message: Commit message. Defaults to a message with job id.
+            pr_title: Pull request title. Defaults to a title with job id.
+            pr_body: Pull request body. Optional.
+            clone_dir: Optional directory to perform clone/work. Defaults to a temp dir.
+
+        Returns:
+            The URL of the created pull request.
+        """
+
+        if token is None:
+            token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if not token:
+            raise RuntimeError("GitHub token not provided. Set GITHUB_TOKEN.")
+
+        if branch_name is None:
+            branch_name = f"mgym/upload-{self.metriq_gym_job.id}"
+        # Default PR title based on job context
+        if pr_title is None:
+            job_type = (
+                self.metriq_gym_job.job_type.value
+                if hasattr(self.metriq_gym_job.job_type, "value")
+                else str(self.metriq_gym_job.job_type)
+            )
+            pr_title = (
+                f"mgym upload: {job_type} on "
+                f"{self.metriq_gym_job.provider_name}/{self.metriq_gym_job.device_name}"
+            )
+        # Align commit message with PR title so browser compare uses a meaningful default
+        if commit_message is None:
+            commit_message = pr_title
+
+        owner, repo_name = repo.split("/", 1)
+
+        # Prepare working directory
+        temp_root = None
+        if clone_dir is None:
+            temp_root = tempfile.mkdtemp(prefix="mgym-upload-")
+            workdir = temp_root
+        else:
+            os.makedirs(clone_dir, exist_ok=True)
+            workdir = clone_dir
+
+        # Determine authenticated user and ensure a fork exists
+        login = self._get_authenticated_login(token)
+        self._ensure_fork(token=token, owner=owner, repo=repo_name, login=login)
+
+        upstream_repo_url = f"https://github.com/{repo}.git"
+        fork_repo = f"{login}/{repo_name}"
+        fork_push_url = f"https://x-access-token:{token}@github.com/{fork_repo}.git"
+
+        repo_path = os.path.join(workdir, repo_name)
+
+        try:
+            # 1) Clone upstream base branch
+            self._run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    base_branch,
+                    upstream_repo_url,
+                    repo_path,
+                ]
+            )
+
+            # Add remote for fork (for checking/pushing)
+            self._run(["git", "-C", repo_path, "remote", "add", "fork", fork_push_url])
+
+            # 2) Prepare branch: if it exists on fork, generate a unique new name; otherwise use given name
+            if self._remote_branch_exists(repo_path, "fork", branch_name):
+                branch_name = self._next_available_branch_name(repo_path, "fork", branch_name)
+            self._run(["git", "-C", repo_path, "checkout", "-b", branch_name])
+
+            # 3) Write JSON/JSONL file
+            out_dir = os.path.join(repo_path, directory) if directory else repo_path
+            os.makedirs(out_dir, exist_ok=True)
+
+            out_filename = filename or f"{self.metriq_gym_job.id}.json"
+            out_path = os.path.join(out_dir, out_filename)
+            data = payload if payload is not None else self.as_dict()
+            # Pretty JSON array, appending by reading existing file if present
+            existing: list = []
+            if append and os.path.exists(out_path):
+                try:
+                    with open(out_path, "r", encoding="utf-8") as rf:
+                        parsed = json.load(rf)
+                        if isinstance(parsed, list):
+                            existing = parsed
+                except Exception:
+                    # If file is corrupt or not a list, start fresh
+                    existing = []
+            # Normalize to list of items (prepend new items so newest appear first)
+            if isinstance(data, list):
+                existing = data + existing
+            else:
+                existing = [data] + existing
+            with open(out_path, "w", encoding="utf-8") as wf:
+                json.dump(existing, wf, indent=2)
+
+            # 4) Use git's configured author identity
+
+            # 5) Commit
+            self._run(["git", "-C", repo_path, "add", os.path.relpath(out_path, repo_path)])
+            self._run(["git", "-C", repo_path, "commit", "-m", commit_message])
+
+            # 6) Push to fork remote
+            self._run(["git", "-C", repo_path, "push", "fork", f"HEAD:{branch_name}"])
+
+            # 7) Open PR via GitHub REST API
+            # 7) Open PR on upstream using head as "<login>:<branch>"
+            compare_url = (
+                f"https://github.com/{owner}/{repo_name}/compare/"
+                f"{base_branch}...{login}:{branch_name}?expand=1"
+            )
+            try:
+                pr_url = self._create_pull_request(
+                    token=token,
+                    owner=owner,
+                    repo=repo_name,
+                    title=pr_title,
+                    head=f"{login}:{branch_name}",
+                    base=base_branch,
+                    body=pr_body,
+                )
+                return pr_url
+            except Exception:
+                # Fallback: return compare URL so user can open PR manually in browser
+                return compare_url
+        finally:
+            if temp_root and os.path.isdir(temp_root):
+                shutil.rmtree(temp_root, ignore_errors=True)
+
+    def _run(self, cmd: list[str]) -> None:
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            stderr = (
+                e.stderr.decode("utf-8", errors="ignore")
+                if isinstance(e.stderr, (bytes, bytearray))
+                else str(e.stderr)
+            )
+            stdout = (
+                e.stdout.decode("utf-8", errors="ignore")
+                if isinstance(e.stdout, (bytes, bytearray))
+                else str(e.stdout)
+            )
+            msg = f"Command failed: {' '.join(cmd)}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            raise RuntimeError(msg) from e
+
+    def _create_pull_request(
+        self,
+        *,
+        token: str,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str,
+        body: Optional[str] = None,
+    ) -> str:
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls"
+        data = {
+            "title": title,
+            "head": head,
+            "base": base,
+        }
+        if body:
+            data["body"] = body
+
+        req = urllib.request.Request(
+            api_url,
+            data=json.dumps(data).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "metriq-gym",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                resp_data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"GitHub PR creation failed: {e.read().decode('utf-8')}") from e
+
+        # Expect an 'html_url' field in the PR response
+        pr_url = resp_data.get("html_url")
+        if not pr_url:
+            raise RuntimeError("GitHub PR creation: missing html_url in response")
+        return pr_url
+
+    def _run_out(self, cmd: list[str]) -> tuple[str, str]:
+        try:
+            res = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            stderr = (
+                e.stderr.decode("utf-8", errors="ignore")
+                if isinstance(e.stderr, (bytes, bytearray))
+                else str(e.stderr)
+            )
+            stdout = (
+                e.stdout.decode("utf-8", errors="ignore")
+                if isinstance(e.stdout, (bytes, bytearray))
+                else str(e.stdout)
+            )
+            msg = f"Command failed: {' '.join(cmd)}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            raise RuntimeError(msg) from e
+        return (
+            res.stdout.decode("utf-8", errors="ignore"),
+            res.stderr.decode("utf-8", errors="ignore"),
+        )
+
+    def _remote_branch_exists(self, repo_path: str, remote: str, branch: str) -> bool:
+        out, _ = self._run_out(["git", "-C", repo_path, "ls-remote", "--heads", remote, branch])
+        return bool(out.strip())
+
+    def _next_available_branch_name(self, repo_path: str, remote: str, base: str) -> str:
+        # Try numeric suffixes to avoid collisions: base-2, base-3, ...
+        for i in range(2, 1000):
+            candidate = f"{base}-{i}"
+            if not self._remote_branch_exists(repo_path, remote, candidate):
+                return candidate
+        # As a last resort, append a timestamp-like suffix
+        import time
+
+        candidate = f"{base}-{int(time.time())}"
+        return candidate
+
+    def _get_authenticated_login(self, token: str) -> str:
+        req = urllib.request.Request(
+            "https://api.github.com/user",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "metriq-gym",
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(
+                f"Failed to resolve authenticated user: {e.read().decode('utf-8')}"
+            ) from e
+        login = data.get("login")
+        if not login:
+            raise RuntimeError("Authenticated user login not found in response")
+        return login
+
+    def _ensure_fork(self, *, token: str, owner: str, repo: str, login: str) -> None:
+        # Check if fork exists
+        if self._repo_exists(token, owner=login, repo=repo):
+            return
+        # Create fork
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/forks"
+        req = urllib.request.Request(
+            api_url,
+            data=json.dumps({"default_branch_only": True}).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "metriq-gym",
+            },
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req).read()
+        except urllib.error.HTTPError as e:
+            # If fork already exists or immediate accept, ignore certain errors
+            if e.code not in (202, 201):
+                # Could be 403/404 in private repos without permission
+                # We'll proceed to poll; if the fork doesn't appear, we'll raise a clear message.
+                pass
+
+        # Forking is asynchronous; poll a few times for availability
+        for _ in range(10):
+            if self._repo_exists(token, owner=login, repo=repo):
+                return
+            time.sleep(1)
+        raise RuntimeError(
+            "Fork creation failed or is not accessible with this token. "
+            "Please fork the repository manually and re-run the command."
+        )
+
+    def _repo_exists(self, token: str, *, owner: str, repo: str) -> bool:
+        api_url = f"https://api.github.com/repos/{owner}/{repo}"
+        req = urllib.request.Request(
+            api_url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "metriq-gym",
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.getcode() == 200
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return False
+            raise

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -25,6 +25,7 @@ class MetriqGymJob:
     device_name: str
     dispatch_time: datetime
     suite_id: str | None = None
+    suite_name: str | None = None
     app_version: str | None = __version__
     result_data: dict[str, Any] | None = None
 
@@ -56,6 +57,7 @@ class MetriqGymJob:
     def __str__(self) -> str:
         rows: list[list[str | None]] = [
             ["suite_id", self.suite_id],
+            ["suite_name", self.suite_name],
             ["id", self.id],
             ["job_type", self.job_type.value],
             ["params", pprint.pformat(self.params)],


### PR DESCRIPTION
Introduces a new feature for uploading benchmark results to a GitHub repository via pull requests, along with supporting CLI options and documentation updates. It also includes minor improvements to job metadata and argument parsing.

Note: `GitHubPRExporter` is heavily generated by Codex, but it's been tested thoroughly and works very well.

# Issue ticket number and link

Fixes #224 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR has been generated by the exporter: https://github.com/unitaryfoundation/metriq-data/pull/6

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
