### PR TITLE
Bug Fix: Index Out of Range Error

### DIFF
--- a/metriq_gym/benchmarks/qedc_benchmarks.py
+++ b/metriq_gym/benchmarks/qedc_benchmarks.py
@@ -145,8 +145,8 @@ def analyze_results(
     metrics.circuit_metrics = job_data.circuit_metrics
 
     # Iterate and get the metrics for each circuit in the list.
-    for curr_idx, (num_qubits, circuit_id) in enumerate(job_data.circuit_identifiers):
-        counts: dict[str, int] = counts_list[curr_idx]
+    for curr_idx, counts in enumerate(counts_list):
+        num_qubits, circuit_id = job_data.circuit_identifiers[curr_idx]
         result_object = CountsWrapper(counts)
 
         # Issue (#731) in QC-App-Oriented-Benchmarks will clean this if/else block.


### PR DESCRIPTION
# Description

The goal of this PR is to fix the bug introduced in #542 involving an index out of range error. I first attempted to recreate the bug, but dispatching and polling the `bernstein-vazirani` benchmark on the `aer_simulator` worked smoothly ([recreate attempt](https://github.com/user-attachments/assets/d6a02e5e-70b4-43ff-bcf0-99fa36830be3)). However, I recalled that when we ran on a certain hardware provider, that not all of the circuits were executed. In this case, the loop in the `analyze_results()` method will have an index error -- it assumes that `counts_list` is the same length as `circuit_identifiers` (the number of counts matches the number of circuits sent for execution). 

The updated code does not make this assumption, and will only compute fidelities for the circuits that we have counts for -- fixing the index our of range error. This fix ensures that the error will not occur again because it is impossible to have more counts in the list than circuits sent for execution. We should add a warning for the user that not all of the circuits were executed. 

No new dependencies were added to implement this fix. 

# Issue ticket number and link

Fixes #542 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I recreated the scenario where `len(counts_list) < len(circuit_identifiers)` and ran the example `bernstein-vazirani` benchmark on the `aer_simulator`. In the attached file, it can be seen that `len(counts_list) = 1` from the fact that only the first circuit has fidelities computed ([test](https://github.com/user-attachments/assets/2d04b693-ef5c-42fe-9c86-86e9845be15d)). Note that it no longer throws an error, but that the remaining circuits are missing fidelities -- because there are no counts for them. 

Additionally, the full suite of tests was ran with `poetry run pytest` to ensure functionality ([pytests](https://github.com/user-attachments/assets/94de6a4f-ccc2-498f-9de9-db97f87ecb73)). 

No configuration changes were made for testing. 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (or not applicable)
