### PR TITLE
flatten_counts: fail loudly when a result has no usable counts

### DIFF
--- a/metriq_gym/helpers/task_helpers.py
+++ b/metriq_gym/helpers/task_helpers.py
@@ -4,6 +4,22 @@ if TYPE_CHECKING:
     from qbraid.runtime.result_data import MeasCount, GateModelResultData
 
 
+def _describe_missing_counts(result: "GateModelResultData") -> str:
+    """Explain why a result has no usable measurement counts, for the error raised by
+    flatten_counts. Distinguishes "provider returned probabilities instead of counts"
+    (e.g. OriginQ simulators) from "no measurement data at all".
+    """
+    try:
+        result.get_probabilities()
+    except ValueError:
+        return "no measurement counts or probabilities are available for this result"
+    return (
+        "the provider returned measurement probabilities instead of sampled counts "
+        "(measurement_counts is None, but probabilities are available). Synthesizing "
+        "sampled counts from probabilities is not supported, so this result cannot be scored"
+    )
+
+
 def flatten_counts(result_data: list["GateModelResultData"]) -> list["MeasCount"]:
     """Flatten the measurement counts from a list of GateModelResultData objects.
 
@@ -11,6 +27,11 @@ def flatten_counts(result_data: list["GateModelResultData"]) -> list["MeasCount"
 
     Example: if we dispatch a job with 2 circuits, IBM returns one result with a list of 2 MeasCount objects.
     If we dispatch the same job to AWS/Rigetti, we get 2 results each with a single MeasCount object.
+
+    Raises:
+        ValueError: If any result carries no usable measurement counts. A result is not
+            silently dropped, since doing so lets a benchmark fall through to reporting a
+            fabricated zero-initialized score as though it had actually been measured.
     """
     flat_counts: list[MeasCount] = []
     for result in result_data:
@@ -18,4 +39,8 @@ def flatten_counts(result_data: list["GateModelResultData"]) -> list["MeasCount"
             flat_counts.extend(result.measurement_counts)
         elif result.measurement_counts is not None:
             flat_counts.append(result.measurement_counts)
+        else:
+            raise ValueError(
+                f"Cannot extract measurement counts: {_describe_missing_counts(result)}."
+            )
     return flat_counts

--- a/metriq_gym/helpers/task_helpers.py
+++ b/metriq_gym/helpers/task_helpers.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from qbraid.runtime.result_data import MeasCount, GateModelResultData
+    from qbraid.runtime.result_data import GateModelResultData, MeasCount
 
 
 def _describe_missing_counts(result: "GateModelResultData") -> str:
@@ -29,16 +29,23 @@ def flatten_counts(result_data: list["GateModelResultData"]) -> list["MeasCount"
     If we dispatch the same job to AWS/Rigetti, we get 2 results each with a single MeasCount object.
 
     Raises:
-        ValueError: If any result carries no usable measurement counts. A result is not
-            silently dropped, since doing so lets a benchmark fall through to reporting a
-            fabricated zero-initialized score as though it had actually been measured.
+        ValueError: If any result carries no usable measurement counts -- this includes
+            `None`, an empty dict, an empty list, or a list containing an empty dict. A
+            result is not silently dropped or contributes zero counts unnoticed, since
+            doing so lets a benchmark fall through to reporting a fabricated
+            zero-initialized score as though it had actually been measured.
     """
     flat_counts: list[MeasCount] = []
     for result in result_data:
-        if isinstance(result.measurement_counts, list):
-            flat_counts.extend(result.measurement_counts)
-        elif result.measurement_counts is not None:
-            flat_counts.append(result.measurement_counts)
+        counts = result.measurement_counts
+        if isinstance(counts, list):
+            if not counts or any(not item for item in counts):
+                raise ValueError(
+                    f"Cannot extract measurement counts: {_describe_missing_counts(result)}."
+                )
+            flat_counts.extend(counts)
+        elif counts:
+            flat_counts.append(counts)
         else:
             raise ValueError(
                 f"Cannot extract measurement counts: {_describe_missing_counts(result)}."

--- a/tests/unit/helpers/test_task_helpers.py
+++ b/tests/unit/helpers/test_task_helpers.py
@@ -57,7 +57,29 @@ def test_flatten_counts_empty():
     assert flat_counts == []
 
 
-def test_flatten_counts_none():
+def test_flatten_counts_none_raises():
     result_data = [GateModelResultData(measurement_counts=None)]
-    flat_counts = flatten_counts(result_data)
-    assert flat_counts == []
+    with pytest.raises(ValueError, match="no measurement counts or probabilities"):
+        flatten_counts(result_data)
+
+
+def test_flatten_counts_probabilities_only_raises():
+    """Regression test for #799: a provider (e.g. OriginQ simulators) that returns
+    probabilities instead of sampled counts must fail loudly, not silently drop the
+    result and let the benchmark report a fabricated 0.0 score."""
+    result_data = [
+        GateModelResultData(measurement_counts=None, measurement_probabilities={"1001": 1.0})
+    ]
+    with pytest.raises(ValueError, match="returned measurement probabilities instead"):
+        flatten_counts(result_data)
+
+
+def test_flatten_counts_partial_none_raises():
+    """One good result and one result with no counts must still raise, not silently
+    return only the good result's counts."""
+    result_data = [
+        GateModelResultData(measurement_counts=MeasCount({"00": 50, "11": 50})),
+        GateModelResultData(measurement_counts=None),
+    ]
+    with pytest.raises(ValueError):
+        flatten_counts(result_data)

--- a/tests/unit/helpers/test_task_helpers.py
+++ b/tests/unit/helpers/test_task_helpers.py
@@ -1,6 +1,7 @@
 import pytest
+from qbraid.runtime.result_data import GateModelResultData, MeasCount
+
 from metriq_gym.helpers.task_helpers import flatten_counts
-from qbraid.runtime.result_data import MeasCount, GateModelResultData
 
 
 @pytest.fixture
@@ -80,6 +81,35 @@ def test_flatten_counts_partial_none_raises():
     result_data = [
         GateModelResultData(measurement_counts=MeasCount({"00": 50, "11": 50})),
         GateModelResultData(measurement_counts=None),
+    ]
+    with pytest.raises(ValueError):
+        flatten_counts(result_data)
+
+
+def test_flatten_counts_empty_dict_raises():
+    """Regression for review comment on #802: measurement_counts={} falls into the
+    `elif ... is not None` branch and would silently contribute zero counts without
+    raising -- the same fabricated-zero-score failure mode #799 was filed for, just
+    reached through an empty dict instead of None."""
+    result_data = [GateModelResultData(measurement_counts=MeasCount({}))]
+    with pytest.raises(ValueError):
+        flatten_counts(result_data)
+
+
+def test_flatten_counts_empty_list_raises():
+    """measurement_counts=[] is `isinstance(..., list)`, so it used to extend with
+    nothing and never raise -- silently dropping the result exactly like the None case
+    #799 was about."""
+    result_data = [GateModelResultData(measurement_counts=[])]
+    with pytest.raises(ValueError):
+        flatten_counts(result_data)
+
+
+def test_flatten_counts_list_with_empty_dict_raises():
+    """A batched result where one circuit's own MeasCount is empty must still raise,
+    not silently contribute a vacuous entry alongside the real one."""
+    result_data = [
+        GateModelResultData(measurement_counts=[MeasCount({"00": 50, "11": 50}), MeasCount({})])
     ]
     with pytest.raises(ValueError):
         flatten_counts(result_data)


### PR DESCRIPTION
## Summary

Any result whose `measurement_counts` is `None` (e.g. an OriginQ simulator, which returns `measurement_probabilities` instead of sampled counts) was silently dropped by `flatten_counts()`. `counts_list` came back empty, the analysis loop in the calling benchmark never ran, and the zero-initialized score got reported as though it had actually been measured — indistinguishable from a genuine `0.0` once written out.

`flatten_counts()` now raises `ValueError` instead of skipping such a result, with a diagnostic that distinguishes "provider returned probabilities instead of counts" (checked via `result.get_probabilities()`, since `GateModelResultData` has no public `measurement_probabilities` accessor) from "no measurement data at all." This is centralized in the one shared helper every benchmark already routes through, so it isn't OriginQ-specific — any provider hitting the same path now fails the same way, as noted in the issue.

Does not implement the issue's secondary suggestion (synthesizing counts from probabilities for OriginQ simulators) — the issue itself calls that a separate, opt-in concern, since the resulting counts wouldn't be sampled and shot-noise-sensitive benchmarks would need to know that.

## Test plan

- [x] Updated `test_flatten_counts_none` → `test_flatten_counts_none_raises` to match the new behavior
- [x] Added `test_flatten_counts_probabilities_only_raises` — direct regression test for the OriginQ scenario (`measurement_probabilities` set, `measurement_counts` is `None`)
- [x] Added `test_flatten_counts_partial_none_raises` — one good result in a batch must not mask one bad result
- [x] Full `tests/unit/helpers/test_task_helpers.py` — 7/7 pass
- [x] `ruff check` / `ruff format` / `mypy` clean on changed files (pinned versions from `pyproject.toml`)

Fixes #799