### PR TITLE
Upload failed jobs as outcome records (error / unsupported / not_applicable)

### DIFF
--- a/docs/content/cli/job-commands.md
+++ b/docs/content/cli/job-commands.md
@@ -175,7 +175,13 @@ mgym job upload <JOB_ID> --outcome unsupported --reason "Compiler rejects 100-qu
 ```
 
 Completed jobs cannot be uploaded with `--outcome`; a completed record always
-supersedes outcome records for the same benchmark instance.
+supersedes outcome records for the same benchmark instance. `--outcome error` is
+reserved for captured failures and cannot be asserted by hand.
+
+Once a failure is recorded, `poll` and `upload` trust it without reconnecting to the
+provider (failed/cancelled statuses are terminal); pass `--no-cache` to `poll` to
+force a re-check. An upload with an explicit `--outcome` goes ahead even if the
+provider cannot be reached, attaching whatever error was recorded locally.
 
 ---
 

--- a/docs/content/cli/job-commands.md
+++ b/docs/content/cli/job-commands.md
@@ -159,6 +159,23 @@ mgym job upload [job_id] [OPTIONS]
 | `--commit-message` | STR | Commit message | `None` |
 | `--clone-dir` | STR | Working directory to clone into (env: `MGYM_UPLOAD_CLONE_DIR`) | `None` |
 | `--dry-run` | BOOL | Do not push or open a PR; print actions only | `False` |
+| `--outcome` | STR | Upload a non-completed outcome record instead of results: `error`, `unsupported` or `not_applicable` | `None` |
+| `--reason` | STR | Human-readable reason for the `--outcome` classification (required for `unsupported` / `not_applicable`) | `None` |
+
+### Failed jobs
+
+A job whose dispatch raised, or whose provider tasks ended in a failed/cancelled
+state, keeps the captured error on the job record (visible in `mgym job view`).
+Uploading such a job produces an `outcome: "error"` record with the verbatim error
+message instead of results. To assert that the device structurally cannot run the
+benchmark instance, reclassify it by hand:
+
+```bash
+mgym job upload <JOB_ID> --outcome unsupported --reason "Compiler rejects 100-qubit LR-QAOA circuits"
+```
+
+Completed jobs cannot be uploaded with `--outcome`; a completed record always
+supersedes outcome records for the same benchmark instance.
 
 ---
 

--- a/docs/content/cli/suite-commands.md
+++ b/docs/content/cli/suite-commands.md
@@ -153,4 +153,8 @@ mgym suite upload [suite_id] [OPTIONS]
 | `--clone-dir` | STR | Working directory to clone into (env: `MGYM_UPLOAD_CLONE_DIR`) | `None` |
 | `--dry-run` | BOOL | Do not push or open a PR; print actions only | `False` |
 
+Jobs in the suite that failed (dispatch raised, or the provider reported a failure)
+are included as `outcome: "error"` records with the captured error, so one failed
+benchmark does not block the upload. Jobs that are still pending do.
+
 ---

--- a/docs/content/uploading/github.md
+++ b/docs/content/uploading/github.md
@@ -121,6 +121,53 @@ A PR is opened with:
 ]
 ```
 
+## Reporting Failed Attempts
+
+Not every attempt produces results. metriq-data records non-completed attempts as
+first-class [outcome records](https://github.com/unitaryfoundation/metriq-data#record-outcomes)
+so that "no data" can be told apart from "tried and failed" or "device cannot run this".
+
+metriq-gym keeps the captured error on the job record when:
+
+- dispatch raises (e.g. the provider rejects the circuit at submission), or
+- a poll finds the provider tasks in a failed/cancelled state.
+
+Uploading such a job produces a record with `outcome: "error"`, `results: null`, and
+the verbatim error in `outcome_detail`:
+
+```bash
+mgym job upload <JOB_ID>
+```
+
+If the failure is structural rather than transient, reclassify it by hand. The
+captured error is attached as evidence:
+
+```bash
+mgym job upload <JOB_ID> --outcome unsupported --reason "Compiler rejects 100-qubit LR-QAOA circuits"
+mgym job upload <JOB_ID> --outcome not_applicable --reason "Benchmark does not apply to this device category"
+```
+
+```json
+{
+  "app_version": "0.7.2",
+  "timestamp": "2026-08-07T12:00:00",
+  "job_type": "Linear Ramp QAOA",
+  "params": { "benchmark_name": "Linear Ramp QAOA", "num_qubits": 100 },
+  "platform": { "provider": "aws", "device": "rigetti_cepheus-1-108q" },
+  "outcome": "unsupported",
+  "outcome_detail": {
+    "reason": "Compiler rejects 100-qubit LR-QAOA circuits",
+    "error_message": "<verbatim provider/compiler error>",
+    "source": "dispatch"
+  },
+  "results": null
+}
+```
+
+`mgym suite upload` includes failed jobs of the suite as `error` outcome records, so
+one failed benchmark does not block uploading the rest. A later successful run of
+the same instance supersedes any outcome record automatically.
+
 ## Contribution Workflow
 
 ### First-Time Contributors

--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -21,6 +21,7 @@ import typer
 
 from tabulate import tabulate
 
+from metriq_gym.constants import RecordOutcome
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 
 
@@ -341,9 +342,10 @@ def job_upload(
         typer.Option("--dry-run", help="Do not push or open a PR; print actions only"),
     ] = False,
     outcome: Annotated[
-        Optional[str],
+        Optional[RecordOutcome],
         typer.Option(
             "--outcome",
+            case_sensitive=False,
             help=(
                 "Upload a non-completed outcome record instead of results: "
                 "'error' (default for failed jobs), 'unsupported' (device cannot run "

--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -340,8 +340,27 @@ def job_upload(
         bool,
         typer.Option("--dry-run", help="Do not push or open a PR; print actions only"),
     ] = False,
+    outcome: Annotated[
+        Optional[str],
+        typer.Option(
+            "--outcome",
+            help=(
+                "Upload a non-completed outcome record instead of results: "
+                "'error' (default for failed jobs), 'unsupported' (device cannot run "
+                "this benchmark instance) or 'not_applicable'. The latter two require --reason."
+            ),
+        ),
+    ] = None,
+    reason: Annotated[
+        Optional[str],
+        typer.Option("--reason", help="Human-readable reason for the --outcome classification"),
+    ] = None,
 ) -> None:
-    """Upload job results to GitHub via pull request."""
+    """Upload job results to GitHub via pull request.
+
+    Failed jobs (dispatch raised, or the provider reported a failure) are uploaded as
+    'error' outcome records carrying the captured error message.
+    """
     from metriq_gym.run import upload_job as _upload_job
 
     args = argparse.Namespace()
@@ -355,6 +374,8 @@ def job_upload(
     args.commit_message = commit_message
     args.clone_dir = clone_dir
     args.dry_run = dry_run
+    args.outcome = outcome
+    args.reason = reason
 
     job_manager = JobManager()
     _upload_job(args, job_manager)

--- a/metriq_gym/constants.py
+++ b/metriq_gym/constants.py
@@ -30,3 +30,20 @@ SCHEMA_MAPPING = {
     JobType.LR_QAOA: "lr_qaoa.schema.json",
     JobType.QAT_OLE: "qat_ole.schema.json",
 }
+
+
+class RecordOutcome(StrEnum):
+    """Non-completed outcomes an uploaded record may declare.
+
+    Mirrors the metriq-data "Record outcomes" contract. A record without an outcome is
+    a completed run. ``ERROR`` is what a machine records for a failed attempt;
+    ``UNSUPPORTED`` and ``NOT_APPLICABLE`` are human classifications asserted at upload
+    time (see ``HUMAN_OUTCOMES``).
+    """
+
+    ERROR = "error"
+    UNSUPPORTED = "unsupported"
+    NOT_APPLICABLE = "not_applicable"
+
+
+HUMAN_OUTCOMES = frozenset({RecordOutcome.UNSUPPORTED, RecordOutcome.NOT_APPLICABLE})

--- a/metriq_gym/dashboard/server.py
+++ b/metriq_gym/dashboard/server.py
@@ -147,6 +147,10 @@ def job_state(raw: dict, state: dict) -> tuple[str, int | None]:
         return "uploaded", None
     if raw.get("result_data") is not None:
         return "ready_to_upload", None
+    if raw.get("error") is not None:
+        # Failure recorded on the job itself (dispatch raised, or a poll saw a
+        # terminal provider failure); no need to wait for a dashboard poll.
+        return "failed", None
     poll = state["polls"].get(jid)
     if poll:
         s = poll["status"]

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -2,16 +2,9 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from metriq_gym.benchmarks.benchmark import BenchmarkResult
+from metriq_gym.constants import RecordOutcome
 from metriq_gym.job_manager import MetriqGymJob
 from metriq_gym.platform import canonical_device_name, canonical_provider_name
-
-
-# Non-completed outcomes a record may carry (metriq-data "Record outcomes" contract).
-# ``error`` is what a machine records for a failed attempt; ``unsupported`` and
-# ``not_applicable`` are human classifications supplied at upload time. A record
-# without an outcome is a completed run.
-RECORD_OUTCOMES = ("error", "unsupported", "not_applicable")
-HUMAN_OUTCOMES = ("unsupported", "not_applicable")
 
 
 class BaseExporter(ABC):
@@ -20,31 +13,30 @@ class BaseExporter(ABC):
         metriq_gym_job: MetriqGymJob,
         result: BenchmarkResult | None,
         *,
-        outcome: str | None = None,
+        outcome: RecordOutcome | str | None = None,
         outcome_reason: str | None = None,
     ):
         """
         Args:
             metriq_gym_job: The job being exported.
             result: The benchmark result, or None for an attempt that produced none.
-            outcome: Explicit non-completed outcome (see ``RECORD_OUTCOMES``). When
-                ``result`` is None and no outcome is given, ``"error"`` is assumed.
+            outcome: Explicit non-completed outcome (a ``RecordOutcome`` or its value).
+                When ``result`` is None and no outcome is given, ``RecordOutcome.ERROR``
+                is assumed. Unknown values raise ``ValueError``.
             outcome_reason: Human-supplied reason stored in ``outcome_detail.reason``.
         """
-        if outcome is not None and outcome not in RECORD_OUTCOMES:
-            raise ValueError(f"Unknown outcome {outcome!r}; expected one of {RECORD_OUTCOMES}")
         self.metriq_gym_job = metriq_gym_job
         self.result = result
-        self.outcome = outcome
-        self.outcome_reason = outcome_reason
+        self.outcome: RecordOutcome | None = None if outcome is None else RecordOutcome(outcome)
+        self.outcome_reason = (outcome_reason or "").strip() or None
         super().__init__()
 
     def _outcome_fields(self) -> dict[str, Any]:
         """Outcome fields for a record that does not describe a completed run.
 
         Returns an empty dict for completed runs. Otherwise the outcome is the one
-        given explicitly, or ``"error"`` when the job simply has no result. The
-        captured job error (if any) is attached verbatim as evidence.
+        given explicitly, or ``RecordOutcome.ERROR`` when the job simply has no
+        result. The captured job error (if any) is attached verbatim as evidence.
         """
         if self.outcome is None and self.result is not None:
             return {}
@@ -57,7 +49,8 @@ class BaseExporter(ABC):
                 detail["error_message"] = str(error["message"])
             if error.get("source"):
                 detail["source"] = str(error["source"])
-        return {"outcome": self.outcome or "error", "outcome_detail": detail or None}
+        outcome = self.outcome or RecordOutcome.ERROR
+        return {"outcome": outcome.value, "outcome_detail": detail or None}
 
     def _derive_device_metadata(self) -> dict[str, Any]:
         """Use metadata collected at dispatch time on the job object."""

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -6,11 +6,58 @@ from metriq_gym.job_manager import MetriqGymJob
 from metriq_gym.platform import canonical_device_name, canonical_provider_name
 
 
+# Non-completed outcomes a record may carry (metriq-data "Record outcomes" contract).
+# ``error`` is what a machine records for a failed attempt; ``unsupported`` and
+# ``not_applicable`` are human classifications supplied at upload time. A record
+# without an outcome is a completed run.
+RECORD_OUTCOMES = ("error", "unsupported", "not_applicable")
+HUMAN_OUTCOMES = ("unsupported", "not_applicable")
+
+
 class BaseExporter(ABC):
-    def __init__(self, metriq_gym_job: MetriqGymJob, result: BenchmarkResult):
+    def __init__(
+        self,
+        metriq_gym_job: MetriqGymJob,
+        result: BenchmarkResult | None,
+        *,
+        outcome: str | None = None,
+        outcome_reason: str | None = None,
+    ):
+        """
+        Args:
+            metriq_gym_job: The job being exported.
+            result: The benchmark result, or None for an attempt that produced none.
+            outcome: Explicit non-completed outcome (see ``RECORD_OUTCOMES``). When
+                ``result`` is None and no outcome is given, ``"error"`` is assumed.
+            outcome_reason: Human-supplied reason stored in ``outcome_detail.reason``.
+        """
+        if outcome is not None and outcome not in RECORD_OUTCOMES:
+            raise ValueError(f"Unknown outcome {outcome!r}; expected one of {RECORD_OUTCOMES}")
         self.metriq_gym_job = metriq_gym_job
         self.result = result
+        self.outcome = outcome
+        self.outcome_reason = outcome_reason
         super().__init__()
+
+    def _outcome_fields(self) -> dict[str, Any]:
+        """Outcome fields for a record that does not describe a completed run.
+
+        Returns an empty dict for completed runs. Otherwise the outcome is the one
+        given explicitly, or ``"error"`` when the job simply has no result. The
+        captured job error (if any) is attached verbatim as evidence.
+        """
+        if self.outcome is None and self.result is not None:
+            return {}
+        detail: dict[str, Any] = {}
+        if self.outcome_reason:
+            detail["reason"] = self.outcome_reason
+        error = getattr(self.metriq_gym_job, "error", None)
+        if isinstance(error, dict):
+            if error.get("message"):
+                detail["error_message"] = str(error["message"])
+            if error.get("source"):
+                detail["source"] = str(error["source"])
+        return {"outcome": self.outcome or "error", "outcome_detail": detail or None}
 
     def _derive_device_metadata(self) -> dict[str, Any]:
         """Use metadata collected at dispatch time on the job object."""
@@ -24,9 +71,13 @@ class BaseExporter(ABC):
     def as_dict(self):
         # Preserve existing top-level fields.
         # For uploads/exports, include the full result payload (already contains score)
-        results_block = self.result.model_dump()
-        if results_block.get("score") is None:
-            results_block.pop("score", None)
+        outcome_fields = self._outcome_fields()
+        results_block: dict[str, Any] | None = None
+        # Non-completed outcomes carry no results payload.
+        if self.result is not None and not outcome_fields:
+            results_block = self.result.model_dump()
+            if results_block.get("score") is None:
+                results_block.pop("score", None)
         # Do not emit a separate uncertainties block; structured fields carry their own
         record = {
             "app_version": self.metriq_gym_job.app_version,
@@ -34,6 +85,7 @@ class BaseExporter(ABC):
             "suite_id": self.metriq_gym_job.suite_id,
             "job_type": self.metriq_gym_job.job_type.value,
             "results": results_block,
+            **outcome_fields,
         }
 
         runtime_seconds = getattr(self.metriq_gym_job, "runtime_seconds", None)

--- a/metriq_gym/exporters/cli_exporter.py
+++ b/metriq_gym/exporters/cli_exporter.py
@@ -10,6 +10,9 @@ class CliExporter(BaseExporter):
         record = self.as_dict()
         pprint(record)
 
+        if self.result is None:
+            return
+
         # Surface the full result object, formatting uncertainties inline when available
         print("\nResults:")
         payload = self.result.model_dump()

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -55,6 +55,9 @@ class MetriqGymJob:
         plat["provider"] = platform_provider
         plat["device"] = platform_device
         self.platform = plat
+        # Tolerate hand-edited/legacy records: ``error`` must be a dict or None.
+        if self.error is not None and not isinstance(self.error, dict):
+            self.error = {"message": str(self.error)}
 
     def record_error(self, source: str, exc_or_message: BaseException | str) -> None:
         """Persist a captured failure on the job record.

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -36,6 +36,8 @@ class MetriqGymJob:
     app_version: str | None = __version__
     result_data: dict[str, Any] | None = None
     runtime_seconds: float | None = None
+    # Captured failure for an attempt that did not complete (see ``record_error``).
+    error: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Populate the canonical dataset platform without rewriting runtime identifiers.
@@ -53,6 +55,28 @@ class MetriqGymJob:
         plat["provider"] = platform_provider
         plat["device"] = platform_device
         self.platform = plat
+
+    def record_error(self, source: str, exc_or_message: BaseException | str) -> None:
+        """Persist a captured failure on the job record.
+
+        ``source`` says where the failure surfaced (``"dispatch"`` when submission to the
+        device raised, ``"poll"`` when the provider reported a terminal failure). The
+        verbatim message is kept so it can be uploaded as evidence on an outcome record.
+        """
+        if isinstance(exc_or_message, BaseException):
+            message = f"{type(exc_or_message).__name__}: {exc_or_message}"
+        else:
+            message = str(exc_or_message)
+        self.error = {
+            "source": source,
+            "message": message,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    @property
+    def failed(self) -> bool:
+        """True when a failure was recorded and no result has been obtained since."""
+        return self.error is not None and self.result_data is None
 
     def num_qubits(self) -> int | None:
         preferred_keys = ("num_qubits", "qubits", "width", "max_qubits")
@@ -120,11 +144,12 @@ class MetriqGymJob:
             ["provider_name", self.provider_name],
             ["device_name", self.device_name],
             ["platform", pprint.pformat(self.platform)],
-            ["provider_job_ids", pprint.pformat(self.data["provider_job_ids"])],
+            ["provider_job_ids", pprint.pformat(self.data.get("provider_job_ids"))],
             ["dispatch_time", self.dispatch_time.isoformat()],
             ["app_version", self.app_version],
             ["runtime_seconds", str(self.runtime_seconds)],
             ["result_data", pprint.pformat(self.result_data)],
+            ["error", pprint.pformat(self.error)],
         ]
         return tabulate(rows, tablefmt="fancy_grid")
 

--- a/metriq_gym/qplatform/job.py
+++ b/metriq_gym/qplatform/job.py
@@ -66,6 +66,83 @@ def total_execution_time(quantum_jobs: Iterable[QuantumJob]) -> float | None:
     return total
 
 
+FAILED_STATUSES = frozenset({JobStatus.FAILED, JobStatus.CANCELLED})
+
+
+@singledispatch
+def failure_reason(quantum_job: QuantumJob) -> str | None:
+    """Best-effort, provider-agnostic error message for a failed job.
+
+    Returns None when the provider exposes no failure detail. Never raises: this is
+    called while recording a failure, and a broken accessor must not mask it.
+    """
+    return None
+
+
+@failure_reason.register
+def _(quantum_job: BraketQuantumTask) -> str | None:
+    try:
+        reason = quantum_job._task.metadata().get("failureReason")
+    except Exception:
+        return None
+    return str(reason) if reason else None
+
+
+@failure_reason.register
+def _(quantum_job: QiskitJob) -> str | None:
+    try:
+        reason = quantum_job._job.error_message()
+    except Exception:
+        return None
+    return str(reason) if reason else None
+
+
+@failure_reason.register
+def _(quantum_job: AzureQuantumJob) -> str | None:
+    try:
+        error_data = quantum_job._job.details.error_data
+    except Exception:
+        return None
+    if error_data is None:
+        return None
+    code = getattr(error_data, "code", None)
+    message = getattr(error_data, "message", None)
+    if code and message:
+        return f"{code}: {message}"
+    return str(message or code) if (message or code) else None
+
+
+@failure_reason.register
+def _(quantum_job: QuantinuumJob) -> str | None:
+    try:
+        reason = quantum_job._get_ref().last_message
+    except Exception:
+        return None
+    return str(reason) if reason else None
+
+
+def failed_jobs_summary(quantum_jobs: Iterable[QuantumJob]) -> str | None:
+    """Describe every task in a terminal failed/cancelled state, or None if there is none.
+
+    The summary is one line per failed task (``<id>: <STATUS> - <reason>``) so that it
+    can be stored verbatim as evidence on the job record.
+    """
+    lines: list[str] = []
+    for qjob in quantum_jobs:
+        try:
+            status = qjob.status()
+        except Exception:
+            continue
+        if status not in FAILED_STATUSES:
+            continue
+        line = f"{qjob.id}: {status.value}"
+        reason = failure_reason(qjob)
+        if reason:
+            line += f" - {reason}"
+        lines.append(line)
+    return "\n".join(lines) if lines else None
+
+
 @dataclass
 class JobStatusInfo:
     """Provider agnostic job status information."""

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -16,7 +16,7 @@ from metriq_gym.cli import list_jobs, prompt_for_job, app as typer_app
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.qplatform.job import failed_jobs_summary, total_execution_time
 from metriq_gym.schema_validator import load_and_validate, validate_and_create_model
-from metriq_gym.constants import JobType
+from metriq_gym.constants import HUMAN_OUTCOMES, JobType, RecordOutcome
 from metriq_gym.resource_estimation import (
     CircuitBatch,
     aggregate_resource_estimates,
@@ -510,21 +510,25 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
 
 def _resolve_upload_outcome(
     args: argparse.Namespace, metriq_job: MetriqGymJob, has_result: bool
-) -> tuple[str | None, str | None] | None:
+) -> tuple[RecordOutcome | None, str | None] | None:
     """Decide which record an upload produces for ``metriq_job``.
 
     Returns ``(outcome, reason)`` where ``outcome`` is None for a completed run, or
     None (after printing why) when nothing should be uploaded.
     """
-    from metriq_gym.exporters.base_exporter import HUMAN_OUTCOMES, RECORD_OUTCOMES
+    raw_outcome = getattr(args, "outcome", None)
+    reason = (getattr(args, "reason", None) or "").strip() or None
 
-    outcome = getattr(args, "outcome", None)
-    reason = getattr(args, "reason", None)
-    if outcome is not None and outcome not in RECORD_OUTCOMES:
-        print(f"Error: --outcome must be one of {', '.join(RECORD_OUTCOMES)}; got '{outcome}'.")
-        return None
+    outcome: RecordOutcome | None = None
+    if raw_outcome is not None:
+        try:
+            outcome = RecordOutcome(str(raw_outcome).strip().lower())
+        except ValueError:
+            choices = ", ".join(o.value for o in RecordOutcome)
+            print(f"Error: --outcome must be one of {choices}; got '{raw_outcome}'.")
+            return None
     if outcome in HUMAN_OUTCOMES and not reason:
-        print(f"Error: --outcome {outcome} requires --reason explaining the classification.")
+        print(f"Error: --outcome {outcome.value} requires --reason explaining the classification.")
         return None
     if reason and outcome is None:
         print("Error: --reason requires --outcome.")
@@ -534,8 +538,8 @@ def _resolve_upload_outcome(
         if outcome is not None:
             print(
                 f"Job {metriq_job.id} completed with results; refusing to upload it as "
-                f"'{outcome}'. Upload the results instead (completed records supersede "
-                "outcome records)."
+                f"'{outcome.value}'. Upload the results instead (completed records "
+                "supersede outcome records)."
             )
             return None
         return (None, None)
@@ -544,13 +548,39 @@ def _resolve_upload_outcome(
         if not metriq_job.failed:
             print(f"Job {metriq_job.id} is not yet completed or has no results.")
             return None
-        outcome = "error"
+        outcome = RecordOutcome.ERROR
     elif not metriq_job.failed:
+        if outcome is RecordOutcome.ERROR:
+            # 'error' is machine evidence, not a human claim: it needs a captured failure.
+            print(
+                f"Job {metriq_job.id} has no recorded failure; 'error' outcomes are "
+                "produced from captured dispatch/poll errors. Poll the job first."
+            )
+            return None
         print(
             f"Warning: job {metriq_job.id} has no recorded failure; uploading it as "
-            f"'{outcome}' on your say-so."
+            f"'{outcome.value}' on your say-so."
         )
     return (outcome, reason)
+
+
+def _fetch_result_for_upload(
+    metriq_job: MetriqGymJob, args: argparse.Namespace, job_manager: JobManager
+) -> Optional[FetchResultOutput]:
+    """``fetch_result`` that degrades gracefully when the provider cannot be reached.
+
+    Failed jobs short-circuit inside ``fetch_result`` and never touch the provider. For
+    everything else, an exception (expired credentials, network, provider outage) is
+    reported as a plain message instead of a traceback so the command fails cleanly.
+    """
+    try:
+        return fetch_result(metriq_job, args, job_manager)
+    except Exception as exc:
+        print(
+            f"✗ Could not fetch status/results for job {metriq_job.id}: {type(exc).__name__}: {exc}"
+        )
+        logger.debug("fetch_result failure traceback", exc_info=True)
+        raise
 
 
 def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
@@ -564,7 +594,15 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     if not metriq_job:
         return
     print("Preparing job upload...")
-    fetch_output = fetch_result(metriq_job, args, job_manager)
+    try:
+        fetch_output = _fetch_result_for_upload(metriq_job, args, job_manager)
+    except Exception:
+        if getattr(args, "outcome", None) is None:
+            return
+        # An explicit outcome is a human claim about the attempt; it can still be
+        # uploaded when the provider is unreachable (any captured error is attached).
+        print("  Continuing with the requested --outcome using the locally recorded job.")
+        fetch_output = None
     resolved = _resolve_upload_outcome(args, metriq_job, has_result=fetch_output is not None)
     if resolved is None:
         return
@@ -586,11 +624,12 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     branch_name = getattr(args, "branch_name", None)
     pr_title = getattr(args, "pr_title", None)
     if outcome is not None:
+        suffix = f"({outcome.value})"
         if pr_title is None:
-            pr_title = f"mgym upload: {metriq_job.job_type.value} on {provider}/{device} ({outcome})"
-        elif not pr_title.endswith(f"({outcome})"):
-            pr_title = f"{pr_title} ({outcome})"
-        print(f"Uploading as '{outcome}' outcome record (no results).")
+            pr_title = f"mgym upload: {metriq_job.job_type.value} on {provider}/{device} {suffix}"
+        elif not pr_title.endswith(suffix):
+            pr_title = f"{pr_title} {suffix}"
+        print(f"Uploading as '{outcome.value}' outcome record (no results).")
     pr_body = getattr(args, "pr_body", None)
     commit_message = getattr(args, "commit_message", None)
     clone_dir = getattr(args, "clone_dir", None)
@@ -713,7 +752,10 @@ def upload_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     # rest of the suite; still-pending jobs do.
     results: list[Any] = []
     for metriq_job in jobs:
-        fetch_output = fetch_result(metriq_job, args, job_manager)
+        try:
+            fetch_output = _fetch_result_for_upload(metriq_job, args, job_manager)
+        except Exception:
+            return
         if fetch_output is None:
             if metriq_job.failed:
                 print(f"Job {metriq_job.id} failed; it will be uploaded as an 'error' outcome.")
@@ -988,8 +1030,15 @@ def fetch_result(
         cached_result = job_result_type.model_validate(metriq_job.result_data)
         return FetchResultOutput(result=cached_result, raw_results=None, from_cache=True)
 
-    if metriq_job.failed:
-        error = metriq_job.error or {}
+    has_provider_jobs = bool(metriq_job.data.get("provider_job_ids"))
+    # ``getattr``: tests pass lightweight job stand-ins without the failure fields.
+    if getattr(metriq_job, "failed", False) and (
+        not has_provider_jobs or not getattr(args, "no_cache", False)
+    ):
+        # Failed/cancelled provider statuses are terminal, so the recorded failure is
+        # trusted without reconnecting to the provider (``--no-cache`` forces a
+        # re-poll). A dispatch failure has nothing to poll at all.
+        error = getattr(metriq_job, "error", None) or {}
         print(f"Job failed at {error.get('source')}: {error.get('message')}")
         return None
 

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -14,7 +14,7 @@ from typing import Any, TYPE_CHECKING, Optional
 from metriq_gym import __version__
 from metriq_gym.cli import list_jobs, prompt_for_job, app as typer_app
 from metriq_gym.job_manager import JobManager, MetriqGymJob
-from metriq_gym.qplatform.job import total_execution_time
+from metriq_gym.qplatform.job import failed_jobs_summary, total_execution_time
 from metriq_gym.schema_validator import load_and_validate, validate_and_create_model
 from metriq_gym.constants import JobType
 from metriq_gym.resource_estimation import (
@@ -259,29 +259,86 @@ def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     print(f"Dispatching {params.benchmark_name}...")
 
     handler: Benchmark = setup_benchmark(args, params, job_type)
-    job_data: BenchmarkData = handler.dispatch_handler(device)
+    try:
+        job_data: BenchmarkData = handler.dispatch_handler(device)
+    except Exception as exc:
+        job_id = _record_dispatch_failure(job_manager, args, device, job_type, params, exc)
+        print(f"✗ {params.benchmark_name} failed to dispatch: {type(exc).__name__}: {exc}")
+        print(f"  Recorded as failed metriq-gym Job ID: {job_id}")
+        print(_OUTCOME_UPLOAD_HINT)
+        logger.debug("Dispatch failure traceback", exc_info=True)
+        return
 
+    job_id = job_manager.add_job(_new_job(args, device, job_type, params, data=asdict(job_data)))
+
+    print(f"✓ {params.benchmark_name} dispatched with metriq-gym Job ID: {job_id}")
+
+
+_OUTCOME_UPLOAD_HINT = (
+    "  Use 'mgym job upload <id>' to report the failure to metriq-data, or "
+    "'mgym job upload <id> --outcome unsupported --reason \"...\"' if the device "
+    "cannot run this benchmark instance."
+)
+
+
+def _new_job(
+    args: argparse.Namespace,
+    device,
+    job_type: JobType,
+    params,
+    *,
+    data: dict[str, Any],
+    suite_id: str | None = None,
+    suite_name: str | None = None,
+) -> MetriqGymJob:
     # Lazy import to avoid heavy modules during CLI cold start
     from metriq_gym.qplatform.device import normalized_metadata
 
-    job_id = job_manager.add_job(
-        MetriqGymJob(
-            id=str(uuid.uuid4()),
-            job_type=job_type,
-            params=params.model_dump(exclude_none=True),
-            data=asdict(job_data),
-            provider_name=args.provider,
-            device_name=args.device,
-            platform={
-                "provider": args.provider,
-                "device": args.device,
-                "device_metadata": normalized_metadata(device),
-            },
-            dispatch_time=datetime.now(),
-        )
+    return MetriqGymJob(
+        id=str(uuid.uuid4()),
+        suite_id=suite_id,
+        suite_name=suite_name,
+        job_type=job_type,
+        params=params.model_dump(exclude_none=True),
+        data=data,
+        provider_name=args.provider,
+        device_name=args.device,
+        platform={
+            "provider": args.provider,
+            "device": args.device,
+            "device_metadata": normalized_metadata(device),
+        },
+        dispatch_time=datetime.now(),
     )
 
-    print(f"✓ {params.benchmark_name} dispatched with metriq-gym Job ID: {job_id}")
+
+def _record_dispatch_failure(
+    job_manager: JobManager,
+    args: argparse.Namespace,
+    device,
+    job_type: JobType,
+    params,
+    exc: BaseException,
+    *,
+    suite_id: str | None = None,
+    suite_name: str | None = None,
+) -> str:
+    """Persist a job whose submission to the device raised.
+
+    The attempt is kept (with the verbatim error) so it can later be uploaded as an
+    outcome record instead of silently disappearing. No provider job ids exist.
+    """
+    job = _new_job(
+        args,
+        device,
+        job_type,
+        params,
+        data={"provider_job_ids": []},
+        suite_id=suite_id,
+        suite_name=suite_name,
+    )
+    job.record_error("dispatch", exc)
+    return job_manager.add_job(job)
 
 
 def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
@@ -345,11 +402,9 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     except QBraidSetupError:
         return
 
-    # Lazy import once per function call
-    from metriq_gym.qplatform.device import normalized_metadata
-
     results = []
     successful_jobs = []
+    failed_jobs = []
 
     suite_id = str(uuid.uuid4())
     for benchmark_entry in selected_benchmarks:
@@ -373,24 +428,35 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
             )
 
             handler: Benchmark = setup_benchmark(args, params, job_type)
-            job_data: BenchmarkData = handler.dispatch_handler(device)
-
-            job_id = job_manager.add_job(
-                MetriqGymJob(
+            try:
+                job_data: BenchmarkData = handler.dispatch_handler(device)
+            except Exception as exc:
+                job_id = _record_dispatch_failure(
+                    job_manager,
+                    args,
+                    device,
+                    job_type,
+                    params,
+                    exc,
                     suite_id=suite_id,
                     suite_name=suite.name,
-                    id=str(uuid.uuid4()),
-                    job_type=job_type,
-                    params=params.model_dump(exclude_none=True),
+                )
+                results.append(
+                    f"✗ {benchmark_entry.name} from {suite.name} failed: "
+                    f"{type(exc).__name__}: {exc} (recorded as failed Job ID: {job_id})"
+                )
+                failed_jobs.append(job_id)
+                continue
+
+            job_id = job_manager.add_job(
+                _new_job(
+                    args,
+                    device,
+                    job_type,
+                    params,
                     data=asdict(job_data),
-                    provider_name=args.provider,
-                    device_name=args.device,
-                    platform={
-                        "provider": args.provider,
-                        "device": args.device,
-                        "device_metadata": normalized_metadata(device),
-                    },
-                    dispatch_time=datetime.now(),
+                    suite_id=suite_id,
+                    suite_name=suite.name,
                 )
             )
 
@@ -413,6 +479,11 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     )
     if successful_jobs:
         print("Use 'mgym suite poll' or 'mgym job poll' to check suite/job status.")
+    if failed_jobs:
+        print(
+            f"{len(failed_jobs)} benchmark(s) failed at dispatch and were recorded as failed jobs."
+        )
+        print(_OUTCOME_UPLOAD_HINT)
 
 
 def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
@@ -422,7 +493,11 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     print("Polling job...")
     fetch_output = fetch_result(metriq_job, args, job_manager)
     if fetch_output is None:
-        print(f"Job {metriq_job.id} is not yet completed or has no results.")
+        if metriq_job.failed:
+            print(f"Job {metriq_job.id} failed and has no results.")
+            print(_OUTCOME_UPLOAD_HINT)
+        else:
+            print(f"Job {metriq_job.id} is not yet completed or has no results.")
         return
     export_job_result(
         args,
@@ -433,17 +508,68 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     )
 
 
+def _resolve_upload_outcome(
+    args: argparse.Namespace, metriq_job: MetriqGymJob, has_result: bool
+) -> tuple[str | None, str | None] | None:
+    """Decide which record an upload produces for ``metriq_job``.
+
+    Returns ``(outcome, reason)`` where ``outcome`` is None for a completed run, or
+    None (after printing why) when nothing should be uploaded.
+    """
+    from metriq_gym.exporters.base_exporter import HUMAN_OUTCOMES, RECORD_OUTCOMES
+
+    outcome = getattr(args, "outcome", None)
+    reason = getattr(args, "reason", None)
+    if outcome is not None and outcome not in RECORD_OUTCOMES:
+        print(f"Error: --outcome must be one of {', '.join(RECORD_OUTCOMES)}; got '{outcome}'.")
+        return None
+    if outcome in HUMAN_OUTCOMES and not reason:
+        print(f"Error: --outcome {outcome} requires --reason explaining the classification.")
+        return None
+    if reason and outcome is None:
+        print("Error: --reason requires --outcome.")
+        return None
+
+    if has_result:
+        if outcome is not None:
+            print(
+                f"Job {metriq_job.id} completed with results; refusing to upload it as "
+                f"'{outcome}'. Upload the results instead (completed records supersede "
+                "outcome records)."
+            )
+            return None
+        return (None, None)
+
+    if outcome is None:
+        if not metriq_job.failed:
+            print(f"Job {metriq_job.id} is not yet completed or has no results.")
+            return None
+        outcome = "error"
+    elif not metriq_job.failed:
+        print(
+            f"Warning: job {metriq_job.id} has no recorded failure; uploading it as "
+            f"'{outcome}' on your say-so."
+        )
+    return (outcome, reason)
+
+
 def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
-    """Upload a job's results to a GitHub repo by opening a Pull Request."""
+    """Upload a job's results to a GitHub repo by opening a Pull Request.
+
+    A job that failed (at dispatch or as reported by the provider) is uploaded as an
+    ``outcome: "error"`` record carrying the captured error. ``--outcome unsupported``
+    / ``not_applicable`` with ``--reason`` reclassifies such a job by hand.
+    """
     metriq_job = prompt_for_job(args.job_id, job_manager)
     if not metriq_job:
         return
     print("Preparing job upload...")
     fetch_output = fetch_result(metriq_job, args, job_manager)
-    if fetch_output is None:
-        print(f"Job {metriq_job.id} is not yet completed or has no results.")
+    resolved = _resolve_upload_outcome(args, metriq_job, has_result=fetch_output is not None)
+    if resolved is None:
         return
-    result = fetch_output.result
+    outcome, reason = resolved
+    result = fetch_output.result if fetch_output is not None else None
 
     repo = getattr(args, "repo", None)
     if not repo:
@@ -459,6 +585,9 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     )
     branch_name = getattr(args, "branch_name", None)
     pr_title = getattr(args, "pr_title", None)
+    if pr_title is None and outcome is not None:
+        pr_title = f"mgym upload: {metriq_job.job_type.value} on {provider}/{device} ({outcome})"
+        print(f"Uploading as '{outcome}' outcome record (no results).")
     pr_body = getattr(args, "pr_body", None)
     commit_message = getattr(args, "commit_message", None)
     clone_dir = getattr(args, "clone_dir", None)
@@ -467,7 +596,9 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     # Write this job's record to a dedicated JSON file in the target directory
     from metriq_gym.exporters.dict_exporter import DictExporter
 
-    record = DictExporter(metriq_job, result).export() | {"params": metriq_job.params}
+    record = DictExporter(metriq_job, result, outcome=outcome, outcome_reason=reason).export() | {
+        "params": metriq_job.params
+    }
 
     try:
         from metriq_gym.exporters.github_pr_exporter import GitHubPRExporter
@@ -506,14 +637,21 @@ def poll_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     if not jobs:
         print(f"No jobs found for suite ID {args.suite_id}.")
         return
+    completed_jobs: list[MetriqGymJob] = []
     results: list[Any] = []
     for metriq_job in jobs:
         fetch_output = fetch_result(metriq_job, args, job_manager)
         if fetch_output is None:
+            if metriq_job.failed:
+                # Failed jobs have nothing to tabulate; report and keep going so one
+                # broken benchmark does not hide the rest of the suite.
+                print(f"Job {metriq_job.id} ({metriq_job.job_type.value}) failed; skipping.")
+                continue
             print(f"Job {metriq_job.id} is not yet completed or has no results.")
             return
+        completed_jobs.append(metriq_job)
         results.append(fetch_output.result)
-    export_suite_results(args, jobs, results)
+    export_suite_results(args, completed_jobs, results)
 
 
 def _get_nested(mapping: dict[str, Any], path: tuple[str, ...]) -> Any | None:
@@ -567,11 +705,17 @@ def upload_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
         print("Error: --repo not provided and MGYM_UPLOAD_REPO not set.")
         return
 
-    # Ensure all results are available first
+    # Ensure every job is either completed or has a recorded failure. Failed jobs are
+    # uploaded as ``outcome: "error"`` records so a broken benchmark does not block the
+    # rest of the suite; still-pending jobs do.
     results: list[Any] = []
     for metriq_job in jobs:
         fetch_output = fetch_result(metriq_job, args, job_manager)
         if fetch_output is None:
+            if metriq_job.failed:
+                print(f"Job {metriq_job.id} failed; it will be uploaded as an 'error' outcome.")
+                results.append(None)
+                continue
             print(f"Job {metriq_job.id} is not yet completed or has no results.")
             return
         results.append(fetch_output.result)
@@ -841,6 +985,12 @@ def fetch_result(
         cached_result = job_result_type.model_validate(metriq_job.result_data)
         return FetchResultOutput(result=cached_result, raw_results=None, from_cache=True)
 
+    if not metriq_job.data.get("provider_job_ids") and metriq_job.error is not None:
+        # Dispatch raised before anything reached the device: there is no benchmark
+        # data to reconstruct and nothing to poll.
+        print(f"Job failed at {metriq_job.error.get('source')}: {metriq_job.error.get('message')}")
+        return None
+
     job_data: "BenchmarkData" = setup_job_data_class(job_type)(**metriq_job.data)
     handler: Benchmark = setup_benchmark(
         args, validate_and_create_model(metriq_job.params), job_type
@@ -874,6 +1024,16 @@ def fetch_result(
         job_manager.update_job(metriq_job)
         return FetchResultOutput(result=result, raw_results=result_data, from_cache=False)
     else:
+        failure = failed_jobs_summary(quantum_jobs)
+        if failure is not None:
+            # Terminal failure reported by the provider: keep the verbatim reason on
+            # the job so it can be uploaded as evidence on an outcome record.
+            metriq_job.record_error("poll", failure)
+            job_manager.update_job(metriq_job)
+            print("Job failed. Provider reported:")
+            for line in failure.splitlines():
+                print(f"- {line}")
+            return None
         print("Job is not yet completed. Current status of tasks:")
         for task in quantum_jobs:
             info = job_status(task)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -985,10 +985,9 @@ def fetch_result(
         cached_result = job_result_type.model_validate(metriq_job.result_data)
         return FetchResultOutput(result=cached_result, raw_results=None, from_cache=True)
 
-    if not metriq_job.data.get("provider_job_ids") and metriq_job.error is not None:
-        # Dispatch raised before anything reached the device: there is no benchmark
-        # data to reconstruct and nothing to poll.
-        print(f"Job failed at {metriq_job.error.get('source')}: {metriq_job.error.get('message')}")
+    if metriq_job.failed:
+        error = metriq_job.error or {}
+        print(f"Job failed at {error.get('source')}: {error.get('message')}")
         return None
 
     job_data: "BenchmarkData" = setup_job_data_class(job_type)(**metriq_job.data)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -585,8 +585,11 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     )
     branch_name = getattr(args, "branch_name", None)
     pr_title = getattr(args, "pr_title", None)
-    if pr_title is None and outcome is not None:
-        pr_title = f"mgym upload: {metriq_job.job_type.value} on {provider}/{device} ({outcome})"
+    if outcome is not None:
+        if pr_title is None:
+            pr_title = f"mgym upload: {metriq_job.job_type.value} on {provider}/{device} ({outcome})"
+        elif not pr_title.endswith(f"({outcome})"):
+            pr_title = f"{pr_title} ({outcome})"
         print(f"Uploading as '{outcome}' outcome record (no results).")
     pr_body = getattr(args, "pr_body", None)
     commit_message = getattr(args, "commit_message", None)

--- a/tests/unit/qplatform/test_job.py
+++ b/tests/unit/qplatform/test_job.py
@@ -167,3 +167,83 @@ def test_total_execution_time_skips_unreported():
     result = total_execution_time([job_not_impl, job_value_error, job_valid])
 
     assert result == pytest.approx(4.2)
+
+
+# --- failure_reason / failed_jobs_summary -----------------------------------------
+
+
+def test_failure_reason_braket_uses_task_failure_reason():
+    from qbraid.runtime import BraketQuantumTask
+    from metriq_gym.qplatform.job import failure_reason
+
+    task = object.__new__(BraketQuantumTask)
+    task._task = SimpleNamespace(
+        metadata=lambda: {"failureReason": "Error occurred during compilation"}
+    )
+    assert failure_reason(task) == "Error occurred during compilation"
+
+
+def test_failure_reason_qiskit_uses_error_message():
+    from metriq_gym.qplatform.job import failure_reason
+
+    job = object.__new__(QiskitJob)
+    job._job = SimpleNamespace(error_message=lambda: "Circuit too deep")
+    assert failure_reason(job) == "Circuit too deep"
+
+
+def test_failure_reason_azure_combines_code_and_message():
+    from metriq_gym.qplatform.job import failure_reason
+
+    job = object.__new__(AzureQuantumJob)
+    job._job = SimpleNamespace(
+        details=SimpleNamespace(error_data=SimpleNamespace(code="InvalidInput", message="bad"))
+    )
+    assert failure_reason(job) == "InvalidInput: bad"
+
+
+def test_failure_reason_quantinuum_uses_last_message():
+    from metriq_gym.qplatform.job import failure_reason
+
+    mock_ref = MagicMock()
+    mock_ref.last_message = "compile error"
+    with patch.object(QuantinuumJob, "_get_ref", return_value=mock_ref):
+        job = QuantinuumJob(job_id="test-job-id")
+        assert failure_reason(job) == "compile error"
+
+
+def test_failure_reason_never_raises_and_unknown_types_return_none():
+    from metriq_gym.qplatform.job import failure_reason
+
+    job = object.__new__(QiskitJob)
+    job._job = SimpleNamespace(error_message=MagicMock(side_effect=RuntimeError("offline")))
+    assert failure_reason(job) is None
+
+    generic = MagicMock(spec=QuantumJob)
+    assert failure_reason(generic) is None
+
+
+def _qiskit_job_with(job_id: str, status: JobStatus, error_message=None) -> QiskitJob:
+    job = object.__new__(QiskitJob)
+    job._job_id = job_id  # backs the read-only ``id`` property
+    job.status = lambda status=status: status
+    job._job = SimpleNamespace(error_message=lambda: error_message)
+    return job
+
+
+def test_failed_jobs_summary_lists_only_terminal_failures():
+    from metriq_gym.qplatform.job import failed_jobs_summary
+
+    summary = failed_jobs_summary(
+        [
+            _qiskit_job_with("run-1", JobStatus.RUNNING),
+            _qiskit_job_with("fail-1", JobStatus.FAILED, "Circuit too deep"),
+            _qiskit_job_with("cancel-1", JobStatus.CANCELLED),
+        ]
+    )
+    assert summary == "fail-1: FAILED - Circuit too deep\ncancel-1: CANCELLED"
+
+
+def test_failed_jobs_summary_none_when_nothing_failed():
+    from metriq_gym.qplatform.job import failed_jobs_summary
+
+    assert failed_jobs_summary([_qiskit_job_with("q-1", JobStatus.QUEUED)]) is None

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -227,6 +227,24 @@ class TestJobCommands:
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
+    def test_job_upload_outcome_is_case_insensitive(self, mock_upload, mock_jm):
+        runner.invoke(
+            app, ["job", "upload", "test-id", "--outcome", "Not_Applicable", "--reason", "r"]
+        )
+        mock_upload.assert_called_once()
+        assert mock_upload.call_args[0][0].outcome == "not_applicable"
+
+    @patch("metriq_gym.cli.JobManager")
+    @patch("metriq_gym.run.upload_job")
+    def test_job_upload_rejects_unknown_outcome_at_cli(self, mock_upload, mock_jm):
+        result = runner.invoke(app, ["job", "upload", "test-id", "--outcome", "exploded"])
+        assert result.exit_code != 0
+        combined = (result.output or "") + (result.stderr or "")
+        assert "not one of" in combined
+        mock_upload.assert_not_called()
+
+    @patch("metriq_gym.cli.JobManager")
+    @patch("metriq_gym.run.upload_job")
     def test_job_upload_with_all_options(self, mock_upload, mock_jm):
         """mgym job upload with all options should pass them correctly."""
         runner.invoke(

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -187,6 +187,8 @@ class TestJobCommands:
         assert "--commit-message" in result.output
         assert "--clone-dir" in result.output
         assert "--dry-run" in result.output
+        assert "--outcome" in result.output
+        assert "--reason" in result.output
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -198,6 +200,30 @@ class TestJobCommands:
         args = mock_upload.call_args[0][0]
         assert args.job_id == "latest"
         assert args.dry_run is True
+        assert args.outcome is None
+        assert args.reason is None
+
+    @patch("metriq_gym.cli.JobManager")
+    @patch("metriq_gym.run.upload_job")
+    def test_job_upload_with_outcome_and_reason(self, mock_upload, mock_jm):
+        """mgym job upload --outcome/--reason should be forwarded to upload_job."""
+        runner.invoke(
+            app,
+            [
+                "job",
+                "upload",
+                "test-id",
+                "--outcome",
+                "unsupported",
+                "--reason",
+                "Compiler rejects 100q circuits",
+            ],
+        )
+
+        mock_upload.assert_called_once()
+        args = mock_upload.call_args[0][0]
+        assert args.outcome == "unsupported"
+        assert args.reason == "Compiler rejects 100q circuits"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")

--- a/tests/unit/test_record_outcomes.py
+++ b/tests/unit/test_record_outcomes.py
@@ -1,0 +1,389 @@
+"""Tests for failure capture on jobs and non-completed outcome uploads.
+
+Mirrors the metriq-data "Record outcomes" contract: a failed attempt is kept on the
+job record (verbatim error) and can be uploaded as an ``outcome`` record instead of
+silently disappearing.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+from qbraid.runtime import JobStatus
+
+from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, BenchmarkScore
+from metriq_gym.constants import JobType
+from metriq_gym.exporters.dict_exporter import DictExporter
+from metriq_gym.job_manager import JobManager, MetriqGymJob
+from metriq_gym.run import (
+    _resolve_upload_outcome,
+    dispatch_job,
+    fetch_result,
+    upload_job,
+    upload_suite,
+)
+
+
+def _job(*, error=None, result_data=None, provider_job_ids=("pj-1",), suite_id=None):
+    return MetriqGymJob(
+        id="job-1",
+        job_type=JobType.WIT,
+        params={"benchmark_name": "WIT", "shots": 10},
+        data={"provider_job_ids": list(provider_job_ids)},
+        provider_name="aws",
+        device_name="arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q",
+        dispatch_time=datetime(2026, 8, 7, 12, 0, 0),
+        suite_id=suite_id,
+        result_data=result_data,
+        error=error,
+    )
+
+
+class DummyResult(BenchmarkResult):
+    value: int
+
+    def compute_score(self):
+        return BenchmarkScore(value=float(self.value), uncertainty=None)
+
+
+@dataclass
+class DummyJobData(BenchmarkData):
+    provider_job_ids: list[str]
+
+
+class FailedQuantumJob:
+    def __init__(self, job_id, status=JobStatus.FAILED):
+        self.id = job_id
+        self._status = status
+
+    def status(self):
+        return self._status
+
+
+# --- job record -----------------------------------------------------------------
+
+
+def test_record_error_from_exception_keeps_type_and_message():
+    job = _job()
+    job.record_error("dispatch", ValueError("Uses 'barrier' which is not supported"))
+    assert job.error["source"] == "dispatch"
+    assert job.error["message"] == "ValueError: Uses 'barrier' which is not supported"
+    datetime.fromisoformat(job.error["timestamp"])
+    assert job.failed
+
+
+def test_failed_is_false_once_results_exist():
+    job = _job(error={"source": "poll", "message": "boom", "timestamp": "t"})
+    assert job.failed
+    job.result_data = {"value": 1}
+    assert not job.failed
+
+
+def test_error_round_trips_through_serialization_and_loads_in_job_manager(tmp_path):
+    job = _job()
+    job.record_error("poll", "pj-1: FAILED - compilation failed")
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+
+    reloaded = JobManager(jobs_file=tmp_path / "jobs.jsonl").get_job("job-1")
+    assert reloaded.error == job.error
+    assert reloaded.failed
+
+
+def test_str_tolerates_missing_provider_job_ids():
+    job = _job(provider_job_ids=())
+    job.data = {}
+    assert "error" in str(job)
+
+
+# --- exporter ------------------------------------------------------------------
+
+
+def test_completed_record_has_no_outcome_fields():
+    record = DictExporter(_job(), DummyResult(value=3)).export()
+    assert "outcome" not in record
+    assert "outcome_detail" not in record
+    assert record["results"]["value"] == 3
+
+
+def test_failed_job_exports_error_outcome_with_captured_message():
+    job = _job(error={"source": "poll", "message": "pj-1: FAILED - boom", "timestamp": "t"})
+    record = DictExporter(job, None).export()
+    assert record["outcome"] == "error"
+    assert record["results"] is None
+    assert record["outcome_detail"] == {"error_message": "pj-1: FAILED - boom", "source": "poll"}
+    # Platform/params machinery is unchanged so the instance is identifiable downstream.
+    assert record["platform"]["provider"] == "aws"
+    assert record["platform"]["device"] == "rigetti_cepheus-1-108q"
+    assert record["job_type"] == "WIT"
+
+
+def test_human_outcome_with_reason_and_evidence():
+    job = _job(error={"source": "dispatch", "message": "ValidationException: x", "timestamp": "t"})
+    record = DictExporter(
+        job, None, outcome="unsupported", outcome_reason="Compiler rejects 100q circuits"
+    ).export()
+    assert record["outcome"] == "unsupported"
+    assert record["outcome_detail"] == {
+        "reason": "Compiler rejects 100q circuits",
+        "error_message": "ValidationException: x",
+        "source": "dispatch",
+    }
+    assert record["results"] is None
+
+
+def test_outcome_without_any_detail_emits_null_detail():
+    record = DictExporter(_job(), None, outcome="not_applicable").export()
+    assert record["outcome"] == "not_applicable"
+    assert record["outcome_detail"] is None
+
+
+def test_explicit_outcome_drops_results_even_if_result_given():
+    record = DictExporter(_job(), DummyResult(value=3), outcome="unsupported").export()
+    assert record["outcome"] == "unsupported"
+    assert record["results"] is None
+
+
+def test_unknown_outcome_rejected():
+    with pytest.raises(ValueError, match="Unknown outcome"):
+        DictExporter(_job(), None, outcome="exploded")
+
+
+def test_outcome_record_is_json_serializable():
+    job = _job(error={"source": "poll", "message": "boom", "timestamp": "t"})
+    json.dumps(DictExporter(job, None).export() | {"params": job.params})
+
+
+# --- fetch_result ---------------------------------------------------------------
+
+
+def _patch_fetch(monkeypatch, quantum_job_factory):
+    import metriq_gym.run as run_mod
+
+    monkeypatch.setattr(run_mod, "setup_benchmark_result_class", lambda *_: DummyResult)
+    monkeypatch.setattr(run_mod, "setup_job_data_class", lambda *_: DummyJobData)
+    monkeypatch.setattr(run_mod, "setup_benchmark", lambda *_, **__: MagicMock())
+    monkeypatch.setattr(run_mod, "load_job", lambda job_id, **__: quantum_job_factory(job_id))
+    monkeypatch.setattr(run_mod, "validate_and_create_model", lambda params: params)
+
+
+def test_fetch_result_records_provider_failure_on_job(monkeypatch, tmp_path, capsys):
+    job = _job()
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    _patch_fetch(monkeypatch, lambda jid: FailedQuantumJob(jid))
+    monkeypatch.setattr(
+        "metriq_gym.run.failed_jobs_summary", lambda qjobs: "pj-1: FAILED - compilation failed"
+    )
+    args = SimpleNamespace(no_cache=False, include_raw=False)
+
+    assert fetch_result(job, args, jm) is None
+
+    assert job.error["source"] == "poll"
+    assert job.error["message"] == "pj-1: FAILED - compilation failed"
+    # Persisted, not just in memory.
+    assert JobManager(jobs_file=tmp_path / "jobs.jsonl").get_job("job-1").failed
+    out = capsys.readouterr().out
+    assert "Job failed. Provider reported:" in out
+    assert "compilation failed" in out
+
+
+def test_fetch_result_pending_job_does_not_record_error(monkeypatch, tmp_path, capsys):
+    job = _job()
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    _patch_fetch(monkeypatch, lambda jid: FailedQuantumJob(jid, JobStatus.QUEUED))
+    monkeypatch.setattr(
+        "metriq_gym.run.job_status",
+        lambda task: SimpleNamespace(status=JobStatus.QUEUED, queue_position=None),
+    )
+    args = SimpleNamespace(no_cache=False, include_raw=False)
+
+    assert fetch_result(job, args, jm) is None
+    assert job.error is None
+    assert "not yet completed" in capsys.readouterr().out
+
+
+def test_fetch_result_short_circuits_dispatch_failure(monkeypatch, tmp_path, capsys):
+    job = _job(
+        provider_job_ids=(),
+        error={"source": "dispatch", "message": "ValidationException: barrier", "timestamp": "t"},
+    )
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
+    _patch_fetch(monkeypatch, load_job)
+    args = SimpleNamespace(no_cache=False, include_raw=False)
+
+    assert fetch_result(job, args, jm) is None
+    assert "Job failed at dispatch" in capsys.readouterr().out
+    load_job.assert_not_called()
+
+
+# --- dispatch -----------------------------------------------------------------
+
+
+def test_dispatch_job_records_failed_attempt(monkeypatch, tmp_path, capsys):
+    class Params(BaseModel):
+        benchmark_name: str = "WIT"
+        shots: int = 10
+
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    device = SimpleNamespace(id="arn:aws:braket:eu-north-1::device/qpu/aqt/Ibex-Q1", num_qubits=12)
+    registry = MagicMock()
+    registry.get_available_benchmarks.return_value = ["WIT"]
+    handler = MagicMock()
+    handler.dispatch_handler.side_effect = ValueError("Uses 'barrier' which is not supported")
+
+    monkeypatch.setattr("os.path.exists", lambda *_: True)
+    monkeypatch.setattr("metriq_gym.run.setup_device", lambda *_: device)
+    monkeypatch.setattr("metriq_gym.run.load_and_validate", lambda *_: Params())
+    monkeypatch.setattr("metriq_gym.run._lazy_registry", lambda: registry)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark", lambda *_, **__: handler)
+    monkeypatch.setattr("metriq_gym.qplatform.device.normalized_metadata", lambda *_: {})
+
+    args = SimpleNamespace(config="wit.json", provider="aws", device=device.id)
+    dispatch_job(args, jm)
+
+    out = capsys.readouterr().out
+    assert "failed to dispatch" in out
+    assert "Recorded as failed" in out
+    (job,) = jm.get_jobs()
+    assert job.failed
+    assert job.error["source"] == "dispatch"
+    assert "Uses 'barrier'" in job.error["message"]
+    assert job.data["provider_job_ids"] == []
+    assert job.params == {"benchmark_name": "WIT", "shots": 10}
+
+
+# --- upload -------------------------------------------------------------------
+
+
+def test_resolve_upload_outcome_failed_job_defaults_to_error():
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    args = SimpleNamespace(outcome=None, reason=None)
+    assert _resolve_upload_outcome(args, job, has_result=False) == ("error", None)
+
+
+def test_resolve_upload_outcome_pending_job_refused(capsys):
+    args = SimpleNamespace(outcome=None, reason=None)
+    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert "not yet completed" in capsys.readouterr().out
+
+
+def test_resolve_upload_outcome_completed_job_is_plain_upload():
+    args = SimpleNamespace(outcome=None, reason=None)
+    assert _resolve_upload_outcome(args, _job(), has_result=True) == (None, None)
+
+
+def test_resolve_upload_outcome_refuses_to_reclassify_completed_job(capsys):
+    args = SimpleNamespace(outcome="unsupported", reason="r")
+    assert _resolve_upload_outcome(args, _job(), has_result=True) is None
+    assert "refusing" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("outcome", ["unsupported", "not_applicable"])
+def test_resolve_upload_outcome_human_outcomes_require_reason(outcome, capsys):
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    args = SimpleNamespace(outcome=outcome, reason=None)
+    assert _resolve_upload_outcome(args, job, has_result=False) is None
+    assert "requires --reason" in capsys.readouterr().out
+    args.reason = "because"
+    assert _resolve_upload_outcome(args, job, has_result=False) == (outcome, "because")
+
+
+def test_resolve_upload_outcome_rejects_unknown_value(capsys):
+    args = SimpleNamespace(outcome="exploded", reason=None)
+    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert "--outcome must be one of" in capsys.readouterr().out
+
+
+def test_upload_job_failed_job_writes_error_outcome_record(monkeypatch, tmp_path, capsys):
+    job = _job(
+        provider_job_ids=(),
+        error={"source": "dispatch", "message": "ValidationException: barrier", "timestamp": "t"},
+    )
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    monkeypatch.setattr("metriq_gym.run.setup_job_data_class", lambda *_: DummyJobData)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark_result_class", lambda *_: DummyResult)
+
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, job, result):
+            captured["result"] = result
+
+        def export(self, **kwargs):
+            captured.update(kwargs)
+            return "DRY-RUN: ok"
+
+    monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", FakeExporter)
+
+    args = SimpleNamespace(
+        job_id="job-1",
+        repo="owner/repo",
+        dry_run=True,
+        no_cache=False,
+        include_raw=False,
+        outcome="unsupported",
+        reason="Device rejects barriers",
+    )
+    upload_job(args, jm)
+
+    out = capsys.readouterr().out
+    assert "Uploading as 'unsupported' outcome record" in out
+    assert "DRY-RUN: ok" in out
+    payload = captured["payload"]
+    assert payload["outcome"] == "unsupported"
+    assert payload["results"] is None
+    assert payload["outcome_detail"]["reason"] == "Device rejects barriers"
+    assert payload["outcome_detail"]["error_message"] == "ValidationException: barrier"
+    assert payload["params"] == job.params
+    assert captured["pr_title"].endswith("(unsupported)")
+    assert captured["result"] is None
+
+
+def test_upload_suite_includes_failed_jobs_as_error_outcomes(monkeypatch, tmp_path, capsys):
+    ok_job = _job(suite_id="suite-1", result_data={"value": 5})
+    failed = _job(
+        provider_job_ids=(),
+        suite_id="suite-1",
+        error={"source": "dispatch", "message": "boom", "timestamp": "t"},
+    )
+    failed.id = "job-2"
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(ok_job)
+    jm.add_job(failed)
+    monkeypatch.setattr("metriq_gym.run.setup_job_data_class", lambda *_: DummyJobData)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark_result_class", lambda *_: DummyResult)
+
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, job, result):
+            pass
+
+        def export(self, **kwargs):
+            captured.update(kwargs)
+            return "DRY-RUN: ok"
+
+    monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", FakeExporter)
+
+    args = SimpleNamespace(
+        suite_id="suite-1", repo="owner/repo", dry_run=True, no_cache=False, include_raw=False
+    )
+    upload_suite(args, jm)
+
+    assert "will be uploaded as an 'error' outcome" in capsys.readouterr().out
+    records = captured["payload"]
+    assert len(records) == 2
+    assert "outcome" not in records[0]
+    assert records[0]["results"]["value"] == 5
+    assert records[1]["outcome"] == "error"
+    assert records[1]["results"] is None
+    assert records[1]["outcome_detail"]["error_message"] == "boom"

--- a/tests/unit/test_record_outcomes.py
+++ b/tests/unit/test_record_outcomes.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 from qbraid.runtime import JobStatus
 
 from metriq_gym.benchmarks.benchmark import BenchmarkData, BenchmarkResult, BenchmarkScore
-from metriq_gym.constants import JobType
+from metriq_gym.constants import JobType, RecordOutcome
 from metriq_gym.exporters.dict_exporter import DictExporter
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.run import (
@@ -149,8 +149,22 @@ def test_explicit_outcome_drops_results_even_if_result_given():
 
 
 def test_unknown_outcome_rejected():
-    with pytest.raises(ValueError, match="Unknown outcome"):
+    with pytest.raises(ValueError):
         DictExporter(_job(), None, outcome="exploded")
+
+
+def test_exporter_accepts_enum_and_value_and_serializes_plain_strings():
+    for outcome in (RecordOutcome.UNSUPPORTED, "unsupported"):
+        record = DictExporter(_job(), None, outcome=outcome, outcome_reason=" r ").export()
+        assert record["outcome"] == "unsupported"
+        assert type(record["outcome"]) is str
+        assert record["outcome_detail"] == {"reason": "r"}
+        json.dumps(record)
+
+
+def test_blank_reason_is_dropped():
+    record = DictExporter(_job(), None, outcome="unsupported", outcome_reason="   ").export()
+    assert record["outcome_detail"] is None
 
 
 def test_outcome_record_is_json_serializable():
@@ -266,7 +280,7 @@ def test_dispatch_job_records_failed_attempt(monkeypatch, tmp_path, capsys):
 def test_resolve_upload_outcome_failed_job_defaults_to_error():
     job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
     args = SimpleNamespace(outcome=None, reason=None)
-    assert _resolve_upload_outcome(args, job, has_result=False) == ("error", None)
+    assert _resolve_upload_outcome(args, job, has_result=False) == (RecordOutcome.ERROR, None)
 
 
 def test_resolve_upload_outcome_pending_job_refused(capsys):
@@ -292,8 +306,11 @@ def test_resolve_upload_outcome_human_outcomes_require_reason(outcome, capsys):
     args = SimpleNamespace(outcome=outcome, reason=None)
     assert _resolve_upload_outcome(args, job, has_result=False) is None
     assert "requires --reason" in capsys.readouterr().out
-    args.reason = "because"
-    assert _resolve_upload_outcome(args, job, has_result=False) == (outcome, "because")
+    args.reason = "  because  "
+    assert _resolve_upload_outcome(args, job, has_result=False) == (
+        RecordOutcome(outcome),
+        "because",
+    )
 
 
 def test_resolve_upload_outcome_rejects_unknown_value(capsys):
@@ -387,3 +404,214 @@ def test_upload_suite_includes_failed_jobs_as_error_outcomes(monkeypatch, tmp_pa
     assert records[1]["outcome"] == "error"
     assert records[1]["results"] is None
     assert records[1]["outcome_detail"]["error_message"] == "boom"
+
+
+# --- hardening ----------------------------------------------------------------
+
+
+def test_resolve_upload_outcome_accepts_enum_and_case_insensitive_strings():
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    for raw in (RecordOutcome.UNSUPPORTED, "UNSUPPORTED", " unsupported "):
+        args = SimpleNamespace(outcome=raw, reason="r")
+        assert _resolve_upload_outcome(args, job, has_result=False) == (
+            RecordOutcome.UNSUPPORTED,
+            "r",
+        )
+
+
+def test_resolve_upload_outcome_blank_reason_counts_as_missing(capsys):
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    args = SimpleNamespace(outcome="unsupported", reason="   ")
+    assert _resolve_upload_outcome(args, job, has_result=False) is None
+    assert "requires --reason" in capsys.readouterr().out
+
+
+def test_resolve_upload_outcome_refuses_hand_asserted_error_without_failure(capsys):
+    args = SimpleNamespace(outcome="error", reason=None)
+    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert "no recorded failure" in capsys.readouterr().out
+
+
+def test_resolve_upload_outcome_human_outcome_on_pending_job_warns(capsys):
+    args = SimpleNamespace(outcome="not_applicable", reason="wrong device class")
+    assert _resolve_upload_outcome(args, _job(), has_result=False) == (
+        RecordOutcome.NOT_APPLICABLE,
+        "wrong device class",
+    )
+    assert "on your say-so" in capsys.readouterr().out
+
+
+def test_fetch_result_trusts_recorded_poll_failure_without_provider(monkeypatch, tmp_path, capsys):
+    job = _job(error={"source": "poll", "message": "pj-1: FAILED - boom", "timestamp": "t"})
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
+    _patch_fetch(monkeypatch, load_job)
+
+    assert fetch_result(job, SimpleNamespace(no_cache=False, include_raw=False), jm) is None
+    assert "Job failed at poll" in capsys.readouterr().out
+    load_job.assert_not_called()
+
+
+def test_fetch_result_no_cache_repolls_poll_failed_job(monkeypatch, tmp_path):
+    job = _job(error={"source": "poll", "message": "pj-1: FAILED - boom", "timestamp": "t"})
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    load_job = MagicMock(side_effect=lambda jid, **__: FailedQuantumJob(jid))
+    _patch_fetch(monkeypatch, load_job)
+    monkeypatch.setattr("metriq_gym.run.failed_jobs_summary", lambda qjobs: "pj-1: FAILED - again")
+
+    assert fetch_result(job, SimpleNamespace(no_cache=True, include_raw=False), jm) is None
+    load_job.assert_called_once()
+    assert job.error["message"] == "pj-1: FAILED - again"
+
+
+def test_fetch_result_no_cache_never_repolls_dispatch_failure(monkeypatch, tmp_path):
+    job = _job(
+        provider_job_ids=(),
+        error={"source": "dispatch", "message": "boom", "timestamp": "t"},
+    )
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
+    _patch_fetch(monkeypatch, load_job)
+
+    assert fetch_result(job, SimpleNamespace(no_cache=True, include_raw=False), jm) is None
+    load_job.assert_not_called()
+
+
+def _upload_args(**overrides):
+    args = SimpleNamespace(
+        job_id="job-1",
+        repo="owner/repo",
+        dry_run=True,
+        no_cache=False,
+        include_raw=False,
+        outcome=None,
+        reason=None,
+    )
+    for k, v in overrides.items():
+        setattr(args, k, v)
+    return args
+
+
+def _install_fake_exporter(monkeypatch):
+    captured = {}
+
+    class FakeExporter:
+        def __init__(self, job, result):
+            captured["result"] = result
+
+        def export(self, **kwargs):
+            captured.update(kwargs)
+            return "DRY-RUN: ok"
+
+    monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", FakeExporter)
+    return captured
+
+
+def test_upload_job_provider_error_without_outcome_fails_cleanly(monkeypatch, tmp_path, capsys):
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(_job())
+    monkeypatch.setattr(
+        "metriq_gym.run.fetch_result", MagicMock(side_effect=RuntimeError("token expired"))
+    )
+    captured = _install_fake_exporter(monkeypatch)
+
+    upload_job(_upload_args(), jm)  # must not raise
+
+    out = capsys.readouterr().out
+    assert "Could not fetch status/results" in out
+    assert "token expired" in out
+    assert "payload" not in captured
+
+
+def test_upload_job_provider_error_with_explicit_outcome_still_uploads(
+    monkeypatch, tmp_path, capsys
+):
+    job = _job(error={"source": "poll", "message": "pj-1: FAILED - boom", "timestamp": "t"})
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    monkeypatch.setattr(
+        "metriq_gym.run.fetch_result", MagicMock(side_effect=RuntimeError("token expired"))
+    )
+    captured = _install_fake_exporter(monkeypatch)
+
+    upload_job(_upload_args(outcome=RecordOutcome.UNSUPPORTED, reason="compiler limit"), jm)
+
+    out = capsys.readouterr().out
+    assert "Continuing with the requested --outcome" in out
+    assert captured["payload"]["outcome"] == "unsupported"
+    assert captured["payload"]["outcome_detail"]["error_message"] == "pj-1: FAILED - boom"
+    assert captured["pr_title"].endswith("(unsupported)")
+
+
+def test_upload_job_custom_title_gets_outcome_suffix(monkeypatch, tmp_path):
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    monkeypatch.setattr("metriq_gym.run.setup_job_data_class", lambda *_: DummyJobData)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark_result_class", lambda *_: DummyResult)
+    captured = _install_fake_exporter(monkeypatch)
+
+    upload_job(_upload_args(pr_title="My title"), jm)
+    assert captured["pr_title"] == "My title (error)"
+
+    upload_job(_upload_args(pr_title="My title (error)"), jm)
+    assert captured["pr_title"] == "My title (error)"
+
+
+def test_upload_job_exporter_failure_is_reported_not_raised(monkeypatch, tmp_path, capsys):
+    job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(job)
+    monkeypatch.setattr("metriq_gym.run.setup_job_data_class", lambda *_: DummyJobData)
+    monkeypatch.setattr("metriq_gym.run.setup_benchmark_result_class", lambda *_: DummyResult)
+
+    class BrokenExporter:
+        def __init__(self, job, result):
+            pass
+
+        def export(self, **kwargs):
+            raise RuntimeError("GitHub token not provided. Set GITHUB_TOKEN.")
+
+    monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", BrokenExporter)
+
+    upload_job(_upload_args(), jm)
+    out = capsys.readouterr().out
+    assert "✗ Upload failed: GitHub token not provided" in out
+
+
+def test_upload_suite_provider_error_fails_cleanly(monkeypatch, tmp_path, capsys):
+    jm = JobManager(jobs_file=tmp_path / "jobs.jsonl")
+    jm.add_job(_job(suite_id="suite-1"))
+    monkeypatch.setattr(
+        "metriq_gym.run.fetch_result", MagicMock(side_effect=RuntimeError("token expired"))
+    )
+    captured = _install_fake_exporter(monkeypatch)
+
+    upload_suite(
+        SimpleNamespace(
+            suite_id="suite-1", repo="owner/repo", dry_run=True, no_cache=False, include_raw=False
+        ),
+        jm,
+    )
+    assert "Could not fetch status/results" in capsys.readouterr().out
+    assert "payload" not in captured
+
+
+def test_malformed_error_field_is_normalized():
+    job = MetriqGymJob(
+        id="x",
+        job_type=JobType.WIT,
+        params={},
+        data={},
+        provider_name="p",
+        device_name="d",
+        dispatch_time=datetime.now(),
+        error="just a string",  # type: ignore[arg-type]
+    )
+    assert job.error == {"message": "just a string"}
+    assert job.failed
+    record = DictExporter(job, None).export()
+    assert record["outcome_detail"] == {"error_message": "just a string"}


### PR DESCRIPTION
# Description

Phase 2 of the outcome-bearing records rollout, following unitaryfoundation/metriq-data#518 (merged): the metriq-gym upload path. Context from that PR: the Cepheus workflow should become *dispatch LR-QAOA 100q → compiler rejects it → upload that job as `unsupported` with the verbatim error attached as evidence*.

Today a failed attempt simply vanishes: `dispatch_job` lets the exception propagate, `dispatch_suite` prints it and moves on, and a provider-side failure (e.g. Rigetti compiler failing on a barrier-laden circuit, #794) leaves the job reported as "not yet completed" forever. Nothing can be uploaded.

## What changes

**Failures are persisted on the job record.** `MetriqGymJob` gains `error: {source, message, timestamp}` (`source` is `dispatch` or `poll`). Unknown fields are already dropped by older readers, so old clients keep loading the db.

- *Dispatch*: if `dispatch_handler(device)` raises, the job is still recorded (with `provider_job_ids: []`, params and platform metadata as usual) plus the verbatim `Type: message`. Both `mgym job dispatch` and `mgym suite dispatch` do this and print the failed job id. Pre-validation failures (missing config, qubit-capacity check) are *not* recorded — they are not device attempts.
- *Poll*: if any task is `FAILED`/`CANCELLED`, `fetch_result` stores a per-task summary (`<id>: FAILED - <reason>`) and persists it. `qplatform.job.failure_reason` extracts the reason best-effort per provider (Braket `failureReason`, IBM `error_message()`, Azure `error_data`, Quantinuum `last_message`); it never raises.
- `mgym job view` shows the error; `mgym job poll` says the job failed and hints at the upload commands.

**Upload produces outcome records.** `mgym job upload <id>`:
- completed job → unchanged;
- failed job → `outcome: "error"`, `results: null`, `outcome_detail: {error_message, source}`;
- `--outcome unsupported|not_applicable --reason "..."` → human reclassification, with the captured error kept as evidence (`--reason` is required for these two);
- `--outcome` on a completed job is refused (completed records supersede outcome records anyway), pending jobs without a recorded failure are refused unless `--outcome` is passed explicitly (then a warning is printed and it is uploaded on the submitter's say-so).

PR title gets an `(<outcome>)` suffix so reviewers can spot them. Example record produced by a `--dry-run`:

```json
{
  "app_version": "0.7.2.dev17",
  "timestamp": "2026-08-19T12:46:48",
  "job_type": "Linear Ramp QAOA",
  "results": null,
  "outcome": "unsupported",
  "outcome_detail": {
    "reason": "Compiler rejects 100-qubit LR-QAOA circuits",
    "error_message": "RuntimeError: Error occurred during compilation: too many qubits in routing",
    "source": "dispatch"
  },
  "platform": {"device": "rigetti_cepheus-1-108q", "provider": "aws"},
  "params": {"benchmark_name": "Linear Ramp QAOA", "graph_type": "1D", "num_qubits": 100}
}
```

**Suites.** `mgym suite upload` includes failed jobs of the suite as `error` outcome records instead of being blocked by them (still-pending jobs still block); `mgym suite poll` skips failed jobs with a message instead of aborting. This matters because dispatch failures are now recorded as suite jobs and would otherwise wedge suite upload.

**Dashboard.** Jobs with a recorded error render as `failed` without waiting for a dashboard poll.

Docs: `docs/content/uploading/github.md` (new "Reporting Failed Attempts" section), `cli/job-commands.md`, `cli/suite-commands.md`.

Out of scope (later phases per the RFC): `score.py` stamping in metriq-data, metriq-web display.

# Issue ticket number and link

Related: unitaryfoundation/metriq-data#518, #794

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- New `tests/unit/test_record_outcomes.py` (24 tests): job `error` round-trip through the jsonl db, exporter outcome fields (error default, human outcomes with reason + evidence, results dropped, unknown outcome rejected), `fetch_result` recording poll failures / not recording pending / short-circuiting dispatch failures, `dispatch_job` recording a failed attempt, `_resolve_upload_outcome` decision table, `upload_job` and `upload_suite` payloads via a fake exporter.
- `tests/unit/qplatform/test_job.py`: `failure_reason` per provider + `failed_jobs_summary`.
- `tests/unit/test_cli_commands.py`: `--outcome` / `--reason` plumbing.
- Full suite: `uv run pytest tests` → 455 passed; `ruff check`, `mypy` clean.
- Manual: seeded a dispatch-failed LR-QAOA job in a scratch db and ran `mgym job poll`, `mgym job upload --dry-run` (plain, `--outcome unsupported` without/with `--reason`) and checked the written JSON (above); dispatched/polled/uploaded a local WIT job to confirm the normal path is unchanged and `--outcome` is refused on it.