### PR TITLE
Annotate BSEQData.topology_graph as rx.PyGraph

### DIFF
--- a/metriq_gym/benchmarks/bseq.py
+++ b/metriq_gym/benchmarks/bseq.py
@@ -28,7 +28,6 @@ References:
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-import networkx as nx
 import rustworkx as rx
 import numpy as np
 
@@ -78,7 +77,7 @@ class BSEQData(BenchmarkData):
 
     shots: int
     num_qubits: int
-    topology_graph: nx.Graph | None = None
+    topology_graph: rx.PyGraph | None = None
     coloring: GraphColoring | dict | None = None
 
 


### PR DESCRIPTION
Closes: #809

`BSEQData.topology_graph` was annotated `nx.Graph | None`, but the value assigned to it is the `rx.PyGraph` returned by `connectivity_graph()`. The annotation has been wrong since BSEQ moved to rustworkx, and it was the only reason `bseq.py` imported networkx.

Everything that consumes the field is already typed against `rx.PyGraph`, so this only corrects the declaration; there is no behaviour change.

Found while closing #240, which reported a sporadic `NetworkXError` from BSEQ. That error is no longer reachable, since the IBM connectivity path is rustworkx end to end.
