### PR TITLE
Note that suite delete does not cancel hardware jobs

### DIFF
--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -482,7 +482,11 @@ def suite_view(
 def suite_delete(
     suite_id: Annotated[Optional[str], typer.Argument(help="Suite ID to delete")] = None,
 ) -> None:
-    """Delete all jobs in a suite from the local database."""
+    """Delete all jobs in a suite from the local database.
+
+    Note: This only removes the jobs from local tracking. It does not cancel
+    jobs running on quantum hardware.
+    """
     from metriq_gym.run import delete_suite as _delete_suite
 
     args = argparse.Namespace()


### PR DESCRIPTION
`mgym job delete` documents that deletion is local-only:

```
Note: This only removes the job from local tracking. It does not cancel
jobs running on quantum hardware.
```

`mgym suite delete` did not, even though it removes every job in the suite at once. The caveat matters more there, since clearing a 22-job suite dispatch looks more like stopping the work than deleting a single job does.

Follow-up to #688, which added the note to `job delete` only.
