### PR TITLE
Serialize concurrent access to localdb.jsonl

### DIFF
--- a/metriq_gym/helpers/file_lock.py
+++ b/metriq_gym/helpers/file_lock.py
@@ -1,0 +1,102 @@
+"""Cross-process advisory locking for the local jobs database."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows
+    import msvcrt
+except ImportError:  # pragma: no cover - platform dependent
+    msvcrt = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+LOCK_SUFFIX = ".lock"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_POLL_INTERVAL = 0.05
+
+
+def lock_path_for(path: Path) -> Path:
+    """Return the sidecar lock file for ``path``.
+
+    The lock lives beside the data file rather than on it. Rewrites replace the
+    data file via ``Path.replace``, so a lock held on the data file would be a
+    lock on an inode that no longer has that name, and a process opening the
+    new file would not see it.
+    """
+    return path.with_name(path.name + LOCK_SUFFIX)
+
+
+def _try_acquire(fd: int) -> None:
+    """Attempt a non-blocking exclusive lock, raising OSError if held."""
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    elif msvcrt is not None:  # pragma: no cover - Windows only
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+
+def _release(fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:  # pragma: no cover - Windows only
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+
+
+@contextmanager
+def exclusive_lock(
+    path: Path,
+    timeout: float = DEFAULT_TIMEOUT,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+) -> Iterator[None]:
+    """Hold an exclusive advisory lock covering ``path`` for the duration.
+
+    Polls rather than blocking so a stuck holder surfaces as a TimeoutError
+    instead of hanging the CLI indefinitely.
+
+    Raises:
+        TimeoutError: if the lock is still held after ``timeout`` seconds.
+    """
+    if fcntl is None and msvcrt is None:  # pragma: no cover - platform dependent
+        logger.warning(
+            "No file locking available on this platform; concurrent metriq-gym "
+            "processes may corrupt %s",
+            path,
+        )
+        yield
+        return
+
+    lock_file = lock_path_for(path)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_file, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                _try_acquire(fd)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out after {timeout}s waiting for the lock on {lock_file}. "
+                        "Another metriq-gym process may be stuck."
+                    )
+                time.sleep(poll_interval)
+        try:
+            yield
+        finally:
+            _release(fd)
+    finally:
+        os.close(fd)

--- a/metriq_gym/helpers/file_lock.py
+++ b/metriq_gym/helpers/file_lock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import time
@@ -23,6 +24,16 @@ except ImportError:  # pragma: no cover - platform dependent
 logger = logging.getLogger(__name__)
 
 LOCK_SUFFIX = ".lock"
+# Raised when the lock is held elsewhere. Anything else (an unsupported
+# filesystem, a bad descriptor) is permanent and must not be retried.
+CONTENTION_ERRNOS = frozenset(
+    {
+        errno.EACCES,
+        errno.EAGAIN,
+        errno.EWOULDBLOCK,
+        errno.EDEADLK,
+    }
+)
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_POLL_INTERVAL = 0.05
 
@@ -87,7 +98,9 @@ def exclusive_lock(
             try:
                 _try_acquire(fd)
                 break
-            except OSError:
+            except OSError as exc:
+                if exc.errno not in CONTENTION_ERRNOS:
+                    raise
                 if time.monotonic() >= deadline:
                     raise TimeoutError(
                         f"Timed out after {timeout}s waiting for the lock on {lock_file}. "

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -175,7 +175,11 @@ class JobManager:
         self._thread_lock = threading.RLock()
         self._lock_depth = 0
         self._lock_cm: Any = None
-        self._load_jobs(warn_if_empty=True)
+        # Under the lock as well: on Windows, Path.replace fails while another
+        # process holds the destination open, so an unlocked read here can make
+        # a concurrent writer's rewrite fail.
+        with self._db_lock():
+            self._load_jobs(warn_if_empty=True)
 
     @contextmanager
     def _db_lock(self):

--- a/metriq_gym/job_manager.py
+++ b/metriq_gym/job_manager.py
@@ -4,6 +4,8 @@ from dataclasses import asdict, dataclass, fields
 from datetime import datetime
 from pathlib import Path
 import shutil
+import threading
+from contextlib import contextmanager
 from metriq_gym._version import __version__
 import json
 import os
@@ -14,6 +16,7 @@ from typing import Any, Sequence
 from tabulate import tabulate
 from metriq_gym.constants import JobType
 from metriq_gym.paths import get_data_db_path
+from metriq_gym.helpers.file_lock import exclusive_lock
 from metriq_gym.platform import canonical_device_name, canonical_provider_name
 
 
@@ -157,7 +160,6 @@ class MetriqGymJob:
         return tabulate(rows, tablefmt="fancy_grid")
 
 
-# TODO: https://github.com/unitaryfoundation/metriq-gym/issues/51
 class JobManager:
     jobs: list[MetriqGymJob]
     jobs_file: Path
@@ -167,12 +169,34 @@ class JobManager:
         # Track original lines (parsed jobs and raw skipped) to preserve order on rewrite.
         # Each entry is (line_number, kind, payload) where kind is "job" or "raw".
         self._line_entries: list[tuple[int, str, Any]] = []
-        self._load_jobs()
+        # Guards this instance against other threads; the file lock guards
+        # against other processes. Both are reentrant so the public methods can
+        # nest calls to _load_jobs and _rewrite_jobs_file.
+        self._thread_lock = threading.RLock()
+        self._lock_depth = 0
+        self._lock_cm: Any = None
+        self._load_jobs(warn_if_empty=True)
+
+    @contextmanager
+    def _db_lock(self):
+        """Hold the jobs-file lock, reentrantly, for the duration."""
+        with self._thread_lock:
+            if self._lock_depth == 0:
+                self._lock_cm = exclusive_lock(self.jobs_file)
+                self._lock_cm.__enter__()
+            self._lock_depth += 1
+            try:
+                yield
+            finally:
+                self._lock_depth -= 1
+                if self._lock_depth == 0:
+                    cm, self._lock_cm = self._lock_cm, None
+                    cm.__exit__(None, None, None)
 
     def _log_skip(self, line_number: int, reason: str) -> None:
         logger.warning(f"Skipping job on line {line_number} in {self.jobs_file}: {reason}")
 
-    def _load_jobs(self):
+    def _load_jobs(self, warn_if_empty: bool = False):
         """
         Initialize the job list by loading valid jobs from the local JSONL db file.
 
@@ -189,6 +213,9 @@ class JobManager:
         All successfully parsed jobs are stored in `self.jobs`.
         """
         self.jobs = []
+        # Must be reset alongside self.jobs: reloading otherwise appends to the
+        # previous entries and a later rewrite duplicates every line.
+        self._line_entries = []
 
         if not self.jobs_file.exists():
             return
@@ -226,24 +253,27 @@ class JobManager:
                 # Keep skipped lines so later rewrites don't drop user data and preserve order
                 self._line_entries.append((line_number, "raw", stripped_line))
 
-        if not self.jobs:
+        if not self.jobs and warn_if_empty:
             logger.warning(f"No valid jobs found in {self.jobs_file}.")
 
     def add_job(self, job: MetriqGymJob) -> str:
-        self.jobs.append(job)
-        max_line = max((ln for ln, _, _ in self._line_entries), default=0)
-        self._line_entries.append((max_line + 1, "job", job))
-        # Append safely without rewriting existing records (minimize data-loss risk)
-        try:
-            with open(self.jobs_file, "a") as file:
-                file.write(job.serialize() + "\n")
-        except Exception as e:
-            self.jobs.pop()
-            self._line_entries.pop()
-            logger.error(
-                f"Failed to append job {job.id} to {self.jobs_file}: {e}. "
-                "Job was not persisted and has been removed from memory."
-            )
+        with self._db_lock():
+            # Refresh first: another process may have written since __init__.
+            self._load_jobs()
+            self.jobs.append(job)
+            max_line = max((ln for ln, _, _ in self._line_entries), default=0)
+            self._line_entries.append((max_line + 1, "job", job))
+            # Append safely without rewriting existing records (minimize data-loss risk)
+            try:
+                with open(self.jobs_file, "a") as file:
+                    file.write(job.serialize() + "\n")
+            except Exception as e:
+                self.jobs.pop()
+                self._line_entries.pop()
+                logger.error(
+                    f"Failed to append job {job.id} to {self.jobs_file}: {e}. "
+                    "Job was not persisted and has been removed from memory."
+                )
         return job.id
 
     def get_jobs(self) -> list[MetriqGymJob]:
@@ -264,17 +294,26 @@ class JobManager:
         return [job for job in self.jobs if job.suite_id == suite_id]
 
     def delete_job(self, job_id: str) -> None:
-        self.jobs = [job for job in self.jobs if job.id != job_id]
-        self._line_entries = [
-            (ln, kind, payload)
-            for (ln, kind, payload) in self._line_entries
-            if not (kind == "job" and isinstance(payload, MetriqGymJob) and payload.id == job_id)
-        ]
-        self._rewrite_jobs_file()
+        with self._db_lock():
+            self._load_jobs()
+            self.jobs = [job for job in self.jobs if job.id != job_id]
+            self._line_entries = [
+                (ln, kind, payload)
+                for (ln, kind, payload) in self._line_entries
+                if not (
+                    kind == "job" and isinstance(payload, MetriqGymJob) and payload.id == job_id
+                )
+            ]
+            self._rewrite_jobs_file()
         logger.info(f"Deleted job with id {job_id} from {self.jobs_file}")
 
     def update_job(self, updated_job: MetriqGymJob) -> None:
         """Persist updated job information to disk."""
+        with self._db_lock():
+            self._load_jobs()
+            self._update_job_locked(updated_job)
+
+    def _update_job_locked(self, updated_job: MetriqGymJob) -> None:
         for idx, job in enumerate(self.jobs):
             if job.id == updated_job.id:
                 self.jobs[idx] = updated_job
@@ -293,8 +332,14 @@ class JobManager:
 
     def _rewrite_jobs_file(self) -> None:
         """Rewrite the jobs file preserving original line order (parsed + skipped)."""
+        with self._db_lock():
+            self._rewrite_jobs_file_locked()
+
+    def _rewrite_jobs_file_locked(self) -> None:
         backup_path = self._backup_jobs_file()
-        temp_file = f"{self.jobs_file}.tmp"
+        # Unique per process: a shared name lets two concurrent rewrites write
+        # the same temp file and race on the replace below.
+        temp_file = f"{self.jobs_file}.{os.getpid()}.tmp"
         try:
             with open(temp_file, "w") as file:
                 for ln, kind, payload in sorted(self._line_entries, key=lambda x: x[0]):

--- a/tests/unit/test_job_manager_locking.py
+++ b/tests/unit/test_job_manager_locking.py
@@ -113,6 +113,10 @@ def test_threads_do_not_interleave_writes(jobs_file):
     assert len({j.id for j in JobManager(jobs_file=jobs_file).get_jobs()}) == 8
 
 
+def _child_delete(path_str: str, job_id: str) -> None:
+    JobManager(jobs_file=Path(path_str)).delete_job(job_id)
+
+
 def _child_add(path_str: str, index: int) -> None:
     JobManager(jobs_file=Path(path_str)).add_job(_job(f"proc-{index}"))
 
@@ -130,6 +134,44 @@ def test_separate_processes_do_not_clobber_each_other(jobs_file):
 
     assert all(p.exitcode == 0 for p in procs)
     assert len({j.id for j in JobManager(jobs_file=jobs_file).get_jobs()}) == 6
+
+
+def test_delete_in_another_process_is_not_undone_by_a_later_update(jobs_file):
+    """The symptom the dashboard works around: a poll after a delete."""
+    seed = JobManager(jobs_file=jobs_file)
+    seed.add_job(_job("deleted-elsewhere"))
+    seed.add_job(_job("kept"))
+
+    # A long-lived manager, holding a view from before the delete.
+    stale = JobManager(jobs_file=jobs_file)
+
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=_child_delete, args=(str(jobs_file), "deleted-elsewhere"))
+    proc.start()
+    proc.join(timeout=120)
+    assert proc.exitcode == 0
+
+    job = _job("kept")
+    job.error = "polled after the delete"
+    stale.update_job(job)
+
+    assert {j.id for j in JobManager(jobs_file=jobs_file).get_jobs()} == {"kept"}
+
+
+def test_permanent_lock_errors_are_not_retried(tmp_path, monkeypatch):
+    """A bad descriptor must surface at once, not after the timeout."""
+    import errno as _errno
+
+    from metriq_gym.helpers import file_lock
+
+    def boom(fd):
+        raise OSError(_errno.EBADF, "bad file descriptor")
+
+    monkeypatch.setattr(file_lock, "_try_acquire", boom)
+    with pytest.raises(OSError) as excinfo:
+        with file_lock.exclusive_lock(tmp_path / "localdb.jsonl", timeout=30):
+            pass
+    assert excinfo.value.errno == _errno.EBADF
 
 
 def test_lock_is_held_against_a_second_holder(tmp_path):

--- a/tests/unit/test_job_manager_locking.py
+++ b/tests/unit/test_job_manager_locking.py
@@ -1,0 +1,146 @@
+"""Concurrency tests for JobManager's on-disk database.
+
+The interesting case is cross-process rather than cross-thread: metriq-gym
+spawns `mgym` subprocesses (the dashboard does this per job), and each builds
+its own JobManager, so an in-process lock alone would serialize nothing.
+"""
+
+import multiprocessing as mp
+import threading
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from metriq_gym.constants import JobType
+from metriq_gym.helpers.file_lock import exclusive_lock, lock_path_for
+from metriq_gym.job_manager import JobManager, MetriqGymJob
+
+
+def _job(job_id: str) -> MetriqGymJob:
+    return MetriqGymJob(
+        id=job_id,
+        job_type=JobType("BSEQ"),
+        params={},
+        data={},
+        provider_name="local",
+        device_name="aer_simulator",
+        dispatch_time=datetime.now(),
+    )
+
+
+@pytest.fixture
+def jobs_file(tmp_path: Path) -> Path:
+    return tmp_path / "localdb.jsonl"
+
+
+def test_reload_does_not_duplicate_line_entries(jobs_file):
+    """Regression: _load_jobs used to append to the previous entries.
+
+    One job then became N duplicate lines on disk after N reloads plus a
+    rewrite. Latent while _load_jobs was only called from __init__, and live
+    as soon as the write paths reload under the lock.
+    """
+    manager = JobManager(jobs_file=jobs_file)
+    manager.add_job(_job("a"))
+
+    for _ in range(3):
+        manager._load_jobs()
+
+    assert len(manager._line_entries) == 1
+    manager._rewrite_jobs_file()
+    assert len(jobs_file.read_text().strip().splitlines()) == 1
+
+
+def test_add_job_picks_up_writes_from_another_manager(jobs_file):
+    """A stale in-memory view must not drop another writer's records."""
+    first = JobManager(jobs_file=jobs_file)
+    second = JobManager(jobs_file=jobs_file)
+
+    first.add_job(_job("from-first"))
+    second.add_job(_job("from-second"))
+
+    on_disk = {line for line in jobs_file.read_text().strip().splitlines()}
+    assert len(on_disk) == 2
+    assert {j.id for j in JobManager(jobs_file=jobs_file).get_jobs()} == {
+        "from-first",
+        "from-second",
+    }
+
+
+def test_delete_does_not_discard_a_concurrent_append(jobs_file):
+    """delete_job rewrites the whole file, so it must reload first."""
+    deleter = JobManager(jobs_file=jobs_file)
+    deleter.add_job(_job("doomed"))
+
+    other = JobManager(jobs_file=jobs_file)
+    other.add_job(_job("survivor"))
+
+    deleter.delete_job("doomed")
+
+    assert {j.id for j in JobManager(jobs_file=jobs_file).get_jobs()} == {"survivor"}
+
+
+def test_update_does_not_discard_a_concurrent_append(jobs_file):
+    updater = JobManager(jobs_file=jobs_file)
+    updater.add_job(_job("target"))
+
+    other = JobManager(jobs_file=jobs_file)
+    other.add_job(_job("survivor"))
+
+    job = updater.get_job("target")
+    job.error = "boom"
+    updater.update_job(job)
+
+    reloaded = JobManager(jobs_file=jobs_file)
+    assert {j.id for j in reloaded.get_jobs()} == {"target", "survivor"}
+    # error is normalized to a dict on serialization round-trip
+    assert reloaded.get_job("target").error == {"message": "boom"}
+
+
+def test_threads_do_not_interleave_writes(jobs_file):
+    JobManager(jobs_file=jobs_file)
+
+    def worker(index: int) -> None:
+        JobManager(jobs_file=jobs_file).add_job(_job(f"job-{index}"))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len({j.id for j in JobManager(jobs_file=jobs_file).get_jobs()}) == 8
+
+
+def _child_add(path_str: str, index: int) -> None:
+    JobManager(jobs_file=Path(path_str)).add_job(_job(f"proc-{index}"))
+
+
+def test_separate_processes_do_not_clobber_each_other(jobs_file):
+    """The case an in-process lock cannot cover."""
+    JobManager(jobs_file=jobs_file)
+
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=_child_add, args=(str(jobs_file), i)) for i in range(6)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=120)
+
+    assert all(p.exitcode == 0 for p in procs)
+    assert len({j.id for j in JobManager(jobs_file=jobs_file).get_jobs()}) == 6
+
+
+def test_lock_is_held_against_a_second_holder(tmp_path):
+    target = tmp_path / "localdb.jsonl"
+    with exclusive_lock(target):
+        with pytest.raises(TimeoutError):
+            with exclusive_lock(target, timeout=0.2, poll_interval=0.01):
+                pass
+
+
+def test_lock_file_sits_beside_the_data_file(tmp_path):
+    """The lock must not be the data file, which rewrites replace."""
+    target = tmp_path / "localdb.jsonl"
+    assert lock_path_for(target) == tmp_path / "localdb.jsonl.lock"

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -723,11 +723,11 @@ def _make_cached_job(val: int) -> MetriqGymJob:
     )
 
 
-def test_fetch_result_uses_cache_when_no_flag(monkeypatch):
+def test_fetch_result_uses_cache_when_no_flag(monkeypatch, tmp_path):
     EXPECTED_CACHED_VALUE = 7
     job = _make_cached_job(EXPECTED_CACHED_VALUE)
-    jm = JobManager()
-    jm.jobs.append(job)
+    jm = JobManager(jobs_file=tmp_path / "localdb.jsonl")
+    jm.add_job(job)
     args = MagicMock()
     args.no_cache = False
     args.include_raw = False
@@ -749,12 +749,12 @@ def test_fetch_result_uses_cache_when_no_flag(monkeypatch):
     assert fetch_output.from_cache is True
 
 
-def test_fetch_result_bypasses_cache_with_flag(monkeypatch):
+def test_fetch_result_bypasses_cache_with_flag(monkeypatch, tmp_path):
     EXPECTED_FRESH_VALUE = 42
     CACHED_VALUE = 7
     job = _make_cached_job(CACHED_VALUE)
-    jm = JobManager()
-    jm.jobs.append(job)
+    jm = JobManager(jobs_file=tmp_path / "localdb.jsonl")
+    jm.add_job(job)
     args = MagicMock()
     args.no_cache = True
     args.include_raw = False
@@ -781,15 +781,15 @@ def test_fetch_result_bypasses_cache_with_flag(monkeypatch):
     )
 
 
-def test_fetch_result_includes_raw_counts_when_flag_set(monkeypatch):
+def test_fetch_result_includes_raw_counts_when_flag_set(monkeypatch, tmp_path):
     """Test that raw counts are returned when include_raw=True."""
     # ...existing code...
 
     EXPECTED_VALUE = 42
     job = _make_cached_job(None)  # No cache, force fresh fetch
     job.result_data = None
-    jm = JobManager()
-    jm.jobs.append(job)
+    jm = JobManager(jobs_file=tmp_path / "localdb.jsonl")
+    jm.add_job(job)
     args = MagicMock()
     args.no_cache = False
     args.include_raw = True


### PR DESCRIPTION
Closes: #51

`JobManager` had no locking of any kind. The dashboard already carried a workaround, with a comment naming the symptom:

```python
# metriq-gym's JobManager has no file locking and rewrites localdb.jsonl wholesale,
# so two concurrent mgym subprocesses can clobber each other's writes (e.g. a poll
# finishing after a delete resurrects the deleted job).
_mgym_write_lock = threading.Lock()
```

## Why not a threading.Lock

The issue originally proposed adding one to `JobManager`. That does not fix this, because the writers are separate processes, each with its own instance. The dashboard's lock only works because every subprocess spawn happens to funnel through that one server process; running `mgym job poll` in a second terminal bypasses it.

This adds advisory file locking (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows) held across the whole load-modify-write in `add_job`, `delete_job` and `update_job`, plus a `threading.RLock` so in-process threads serialize as well. Both are reentrant, so the public methods can nest calls to `_load_jobs` and `_rewrite_jobs_file`.

The lock is a sidecar file rather than the data file itself. `_rewrite_jobs_file` replaces the data file via `Path.replace`, so a lock held on it would be a lock on an inode that no longer carries that name, invisible to a process that opened the new one. Acquisition polls with a timeout rather than blocking, so a stuck holder surfaces as a `TimeoutError` instead of hanging the CLI.

## Two other races closed

`_load_jobs` reset `self.jobs` but not `self._line_entries`, so it appended to whatever was already there. Latent while it was only called once from `__init__`, and live as soon as the write paths reload under the lock. On unmodified `main`:

```
after add:            jobs=1  line_entries=1
after 1 reload:       jobs=1  line_entries=2
after 2 reloads:      jobs=1  line_entries=3
lines on disk after rewrite: 3
```

`_rewrite_jobs_file` wrote to a fixed `{jobs_file}.tmp`, so two concurrent rewrites shared a temp path and raced on the replace. Now pid-qualified.

## Test hygiene fix, found along the way

Three `fetch_result` tests constructed `JobManager()` with no argument, which resolves to the real user database at `~/.local/share/metriq-gym/localdb.jsonl`. They were reading and rewriting it on every test run, leaving `.bak` files behind. Surfaced because `update_job` now reloads under the lock and so rejects a job that was only injected into memory. They use a temp file and persist the job properly now, and I verified the suite leaves the real database byte-identical.

## Tests

`tests/unit/test_job_manager_locking.py` covers the reload duplication regression, concurrent add/delete/update across separate `JobManager` instances, 8 threads, 6 spawned processes, lock contention timeout, and the sidecar path. I checked they bite: disabling just the reload in `delete_job` fails `test_delete_does_not_discard_a_concurrent_append`.
