### PR TITLE
Share common benchmark schema properties via $ref

### DIFF
--- a/metriq_gym/schema_validator.py
+++ b/metriq_gym/schema_validator.py
@@ -10,6 +10,7 @@ from importlib import resources
 from metriq_gym.constants import JobType, SCHEMA_MAPPING
 
 SCHEMA_DIR_NAME = "schemas"
+COMMON_SCHEMA_FILENAME = "common.schema.json"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_SCHEMA_DIR = os.path.join(CURRENT_DIR, SCHEMA_DIR_NAME)
 BENCHMARK_NAME_KEY = "benchmark_name"
@@ -43,6 +44,50 @@ def load_json_file(file_path: str) -> dict:
         return json.load(file)
 
 
+def _resolve_refs(node: Any, defs: dict[str, Any]) -> Any:
+    """Inline every local $ref against the shared definitions.
+
+    jsonschema resolves $ref on its own, but create_pydantic_model reads
+    field_schema["type"] directly and would raise KeyError on a bare reference.
+    Materializing the schema up front keeps both consumers working on the same
+    fully-expanded dict.
+
+    Keywords alongside a $ref override the referenced definition, which is how a
+    benchmark declares a different default without restating the property. This
+    is draft 2020-12 behaviour; all bundled schemas declare that dialect.
+    """
+    if isinstance(node, list):
+        return [_resolve_refs(item, defs) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    ref = node.get("$ref")
+    if isinstance(ref, str):
+        name = ref.rsplit("/", 1)[-1]
+        if name not in defs:
+            raise ValueError(f"Unknown schema reference: {ref}")
+        merged = dict(defs[name])
+        # Siblings win over the shared definition.
+        merged.update({k: v for k, v in node.items() if k != "$ref"})
+        return _resolve_refs(merged, defs)
+
+    return {key: _resolve_refs(value, defs) for key, value in node.items()}
+
+
+def load_common_defs(schema_dir: str = DEFAULT_SCHEMA_DIR) -> dict[str, Any]:
+    """Load the shared $defs used by benchmark schemas."""
+    if schema_dir != DEFAULT_SCHEMA_DIR:
+        candidate = os.path.join(schema_dir, COMMON_SCHEMA_FILENAME)
+        if not os.path.isfile(candidate):
+            return {}
+        return load_json_file(candidate).get("$defs", {})
+
+    resource_path = _schema_resource_path(COMMON_SCHEMA_FILENAME)
+    if resource_path is None:
+        return {}
+    return load_json_file(resource_path).get("$defs", {})
+
+
 def load_schema(benchmark_name: str, schema_dir: str = DEFAULT_SCHEMA_DIR) -> dict:
     """Load a JSON schema based on the benchmark name.
 
@@ -57,14 +102,14 @@ def load_schema(benchmark_name: str, schema_dir: str = DEFAULT_SCHEMA_DIR) -> di
         candidate = os.path.join(schema_dir, schema_filename)
         if not os.path.isfile(candidate):
             raise FileNotFoundError(f"Schema file not found: {candidate}")
-        return load_json_file(candidate)
+        return _resolve_refs(load_json_file(candidate), load_common_defs(schema_dir))
 
     resource_path = _schema_resource_path(schema_filename)
     if resource_path is None:
         raise FileNotFoundError(
             f"Schema file '{schema_filename}' not found in package resources or '{DEFAULT_SCHEMA_DIR}'."
         )
-    return load_json_file(resource_path)
+    return _resolve_refs(load_json_file(resource_path), load_common_defs(schema_dir))
 
 
 def create_pydantic_model(schema: dict[str, Any]) -> Any:

--- a/metriq_gym/schemas/bernstein_vazirani.schema.json
+++ b/metriq_gym/schemas/bernstein_vazirani.schema.json
@@ -12,39 +12,25 @@
       "description": "Name of the benchmark. Must be 'Bernstein-Vazirani' for this schema."
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [5000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "min_qubits": {
       "type": "integer",
       "description": "Minimum number of qubits to start generating circuits for the benchmark.",
       "default": 2,
       "minimum": 2,
-      "examples": [4]
+      "examples": [
+        4
+      ]
     },
     "max_qubits": {
-      "type": "integer",
-      "description": "Maximum number of qubits to stop generating circuits for the benchmark.",
-      "default": 6,
-      "minimum": 2,
-      "examples": [7]
+      "$ref": "common.schema.json#/$defs/max_qubits"
     },
     "skip_qubits": {
-      "type": "integer",
-      "description": "The step size for generating circuits from the min to max qubit sizes. ",
-      "default": 1,
-      "minimum": 1,
-      "examples": [2]
+      "$ref": "common.schema.json#/$defs/skip_qubits"
     },
     "max_circuits": {
-      "type": "integer",
-      "description": "Maximum number of circuits generated for each qubit size in the benchmark.",
-      "default": 3,
-      "minimum": 1,
-      "examples": [9]
+      "$ref": "common.schema.json#/$defs/max_circuits"
     },
     "method": {
       "type": "integer",
@@ -52,17 +38,25 @@
       "default": 1,
       "minimum": 1,
       "maximum": 2,
-      "examples": [2]
+      "examples": [
+        2
+      ]
     },
     "input_value": {
       "type": "integer",
       "description": "Specifies the secret int for the benchmark; note that max_circuits must be 1 if this is used.",
-      "examples": [1]
+      "examples": [
+        1
+      ]
     }
   },
-  "required": ["benchmark_name"],
+  "required": [
+    "benchmark_name"
+  ],
   "if": {
-    "required": ["input_value"]
+    "required": [
+      "input_value"
+    ]
   },
   "then": {
     "properties": {

--- a/metriq_gym/schemas/bseq.schema.json
+++ b/metriq_gym/schemas/bseq.schema.json
@@ -11,16 +11,14 @@
       "description": "Name of the benchmark. Must be 'BSEQ' for this schema."
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) to use for the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [1000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "max_colors": {
       "type": "integer",
       "description": "If specified, Maximum number of colors to use in the BSEQ benchmark. If unspecified, all colors will be used."
     }
   },
-  "required": ["benchmark_name"]
+  "required": [
+    "benchmark_name"
+  ]
 }

--- a/metriq_gym/schemas/clops.schema.json
+++ b/metriq_gym/schemas/clops.schema.json
@@ -15,55 +15,81 @@
       "description": "Number of qubits (width) in the circuits.",
       "default": 10,
       "minimum": 1,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "num_layers": {
       "type": "integer",
       "description": "Number of repeated layers or blocks in the circuit.",
       "default": 100,
       "minimum": 1,
-      "examples": [100]
+      "examples": [
+        100
+      ]
     },
     "num_circuits": {
       "type": "integer",
       "description": "Number of circuits to generate and run for this benchmark.",
       "default": 100,
       "minimum": 1,
-      "examples": [100]
+      "examples": [
+        100
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) per circuit.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [1000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "seed": {
       "type": "integer",
       "description": "Random seed for reproducibility.",
       "default": 12345,
-      "examples": [12345, 42]
+      "examples": [
+        12345,
+        42
+      ]
     },
     "two_qubit_gate": {
       "type": "string",
       "description": "Two-qubit gate to use. This should be a native entangling gate supported by the device.",
       "default": "cz",
-      "enum": ["cz", "cx", "ecr"],
-      "examples": ["cz", "cx", "ecr"]
+      "enum": [
+        "cz",
+        "cx",
+        "ecr"
+      ],
+      "examples": [
+        "cz",
+        "cx",
+        "ecr"
+      ]
     },
     "mode": {
       "type": "string",
       "description": "How circuits are submitted. 'instantiated' binds parameters locally and sends concrete circuits (works with any provider). 'parameterized' sends a single parameterized circuit with parameter arrays via SamplerV2 PUBs (requires ibm provider). 'twirled' sends a fixed circuit and delegates randomization to the Sampler's gate twirler (requires ibm provider).",
       "default": "instantiated",
-      "enum": ["instantiated", "parameterized", "twirled"],
-      "examples": ["instantiated", "parameterized", "twirled"]
+      "enum": [
+        "instantiated",
+        "parameterized",
+        "twirled"
+      ],
+      "examples": [
+        "instantiated",
+        "parameterized",
+        "twirled"
+      ]
     },
     "use_session": {
       "type": "boolean",
       "description": "Whether to use a session for running circuits. Currently, only supported by ibm provider",
       "default": false,
-      "examples": [true, false]
+      "examples": [
+        true,
+        false
+      ]
     }
   },
-  "required": ["benchmark_name"]
+  "required": [
+    "benchmark_name"
+  ]
 }

--- a/metriq_gym/schemas/common.schema.json
+++ b/metriq_gym/schemas/common.schema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "metriq-gym/common.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Common benchmark properties",
+  "description": "Property definitions shared across benchmark schemas. Reference these with $ref rather than restating them. Keywords given as siblings of the $ref override the shared definition, which is how a benchmark declares a different default without forking the whole property.",
+  "$defs": {
+    "shots": {
+      "type": "integer",
+      "description": "Number of measurement shots (repetitions) per circuit.",
+      "default": 1000,
+      "minimum": 1,
+      "examples": [
+        1000
+      ]
+    },
+    "max_qubits": {
+      "type": "integer",
+      "description": "Maximum number of qubits to stop generating circuits for the benchmark.",
+      "default": 6,
+      "minimum": 2,
+      "examples": [
+        7
+      ]
+    },
+    "skip_qubits": {
+      "type": "integer",
+      "description": "The step size for generating circuits from the min to max qubit sizes.",
+      "default": 1,
+      "minimum": 1,
+      "examples": [
+        2
+      ]
+    },
+    "max_circuits": {
+      "type": "integer",
+      "description": "Maximum number of circuits generated for each qubit size in the benchmark.",
+      "default": 3,
+      "minimum": 1,
+      "examples": [
+        9
+      ]
+    }
+  }
+}

--- a/metriq_gym/schemas/eplg.schema.json
+++ b/metriq_gym/schemas/eplg.schema.json
@@ -14,7 +14,12 @@
       "type": "integer",
       "description": "Number of qubits in the linear chain for layer fidelity measurement.",
       "minimum": 4,
-      "examples": [10, 20, 50, 100]
+      "examples": [
+        10,
+        20,
+        50,
+        100
+      ]
     },
     "lengths": {
       "type": "array",
@@ -23,34 +28,58 @@
         "minimum": 1
       },
       "description": "Number of layers (circuit depths) in the randomized benchmarking protocol.",
-      "default": [2, 4, 8, 16],
-      "examples": [[2, 4], [2, 4, 8, 16]]
+      "default": [
+        2,
+        4,
+        8,
+        16
+      ],
+      "examples": [
+        [
+          2,
+          4
+        ],
+        [
+          2,
+          4,
+          8,
+          16
+        ]
+      ]
     },
     "num_samples": {
       "type": "integer",
       "description": "Number of random circuits sampled per depth in the randomized benchmarking protocol.",
       "default": 3,
       "minimum": 1,
-      "examples": [3, 6, 10]
+      "examples": [
+        3,
+        6,
+        10
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots per circuit.",
-      "default": 100,
-      "minimum": 1,
-      "examples": [100, 1000]
+      "$ref": "common.schema.json#/$defs/shots",
+      "default": 100
     },
     "seed": {
       "type": "integer",
       "description": "Random seed for reproducibility.",
       "default": 12345,
-      "examples": [12345, 42]
+      "examples": [
+        12345,
+        42
+      ]
     },
     "two_qubit_gate": {
       "type": "string",
       "description": "Device-dependent two-qubit gate to use. This should be a native entangling gate supported by the target provider/device; change it if circuit construction or transpilation fails.",
       "default": "cz",
-      "examples": ["cz", "cx", "ecr"]
+      "examples": [
+        "cz",
+        "cx",
+        "ecr"
+      ]
     },
     "one_qubit_basis_gates": {
       "type": "array",
@@ -58,21 +87,38 @@
         "type": "string"
       },
       "description": "Device-dependent single-qubit basis gates for the LayerFidelity experiment. They should complement the chosen two-qubit gate to form a universal gate set supported by the target provider/device; change them if circuit construction or transpilation fails.",
-      "default": ["rz", "rx", "x"],
-      "examples": [["rz", "rx", "x"]]
+      "default": [
+        "rz",
+        "rx",
+        "x"
+      ],
+      "examples": [
+        [
+          "rz",
+          "rx",
+          "x"
+        ]
+      ]
     },
     "decompose_clifford_ops": {
       "type": "boolean",
       "description": "Decompose the parameterized clifford operation types in the circuit to primitive operations; this may be necessary for providers that don't support Qiskit clifford primitives",
       "default": false,
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "constrain_rb_offset_b": {
       "type": "boolean",
       "description": "If true, constrain the RB fit offset parameter b (around its expected baseline) to stabilize LayerFidelity fits when using a truncated RB depth schedule.",
       "default": false,
-      "examples": [true]
+      "examples": [
+        true
+      ]
     }
   },
-  "required": ["benchmark_name", "num_qubits_in_chain"]
+  "required": [
+    "benchmark_name",
+    "num_qubits_in_chain"
+  ]
 }

--- a/metriq_gym/schemas/hidden_shift.schema.json
+++ b/metriq_gym/schemas/hidden_shift.schema.json
@@ -12,39 +12,25 @@
       "description": "Name of the benchmark. Must be 'Hidden Shift' for this schema."
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [5000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "min_qubits": {
       "type": "integer",
       "description": "Minimum number of qubits to start generating circuits for the benchmark.",
       "default": 2,
       "minimum": 2,
-      "examples": [4]
+      "examples": [
+        4
+      ]
     },
     "max_qubits": {
-      "type": "integer",
-      "description": "Maximum number of qubits to stop generating circuits for the benchmark.",
-      "default": 6,
-      "minimum": 2,
-      "examples": [7]
+      "$ref": "common.schema.json#/$defs/max_qubits"
     },
     "skip_qubits": {
-      "type": "integer",
-      "description": "The step size for generating circuits from the min to max qubit sizes. ",
-      "default": 1,
-      "minimum": 1,
-      "examples": [2]
+      "$ref": "common.schema.json#/$defs/skip_qubits"
     },
     "max_circuits": {
-      "type": "integer",
-      "description": "Maximum number of circuits generated for each qubit size in the benchmark.",
-      "default": 3,
-      "minimum": 1,
-      "examples": [9]
+      "$ref": "common.schema.json#/$defs/max_circuits"
     },
     "method": {
       "type": "integer",
@@ -55,12 +41,18 @@
     "input_value": {
       "type": "integer",
       "description": "Specifies the secret int for the benchmark; note that max_circuits must be 1 if this is used.",
-      "examples": [1]
+      "examples": [
+        1
+      ]
     }
   },
-  "required": ["benchmark_name"],
+  "required": [
+    "benchmark_name"
+  ],
   "if": {
-    "required": ["input_value"]
+    "required": [
+      "input_value"
+    ]
   },
   "then": {
     "properties": {

--- a/metriq_gym/schemas/lr_qaoa.schema.json
+++ b/metriq_gym/schemas/lr_qaoa.schema.json
@@ -13,59 +13,98 @@
     "graph_type": {
       "type": "string",
       "description": "Type of the graph, '1D':1D chain graph, 'NL': Native Layout graph, or 'FC': Fully connected graph.",
-      "examples":["FC", "NL", "1D"]
+      "examples": [
+        "FC",
+        "NL",
+        "1D"
+      ]
     },
     "num_qubits": {
       "type": "integer",
       "description": "Number of qubits in the LR-QAOA circuit(s).",
       "minimum": 2,
-      "examples": [10, 20, 100]
+      "examples": [
+        10,
+        20,
+        100
+      ]
     },
     "qaoa_layers": {
       "description": "List of the different layers depth of LR-QAOA.",
       "type": "array",
-      "items": {"type": "integer",
-                "minimum": 3},
+      "items": {
+        "type": "integer",
+        "minimum": 3
+      },
       "minItems": 1,
-      "examples": [[3,4,5], [3]],
-      "default": [3, 5, 7, 10, 15, 20]
+      "examples": [
+        [
+          3,
+          4,
+          5
+        ],
+        [
+          3
+        ]
+      ],
+      "default": [
+        3,
+        5,
+        7,
+        10,
+        15,
+        20
+      ]
     },
     "delta_beta": {
       "type": "number",
       "description": "Beta parameters slope in the linear function of LR-QAOA.",
-      "default":0.3,
+      "default": 0.3,
       "minimum": 0.0,
       "maximum": 2.0,
-      "examples": [0.1, 0.3, 0.5]
+      "examples": [
+        0.1,
+        0.3,
+        0.5
+      ]
     },
     "delta_gamma": {
       "type": "number",
       "description": "Gamma parameters slope in the linear function of LR-QAOA.",
-      "default":0.3,
+      "default": 0.3,
       "minimum": 0.0,
-      "maximum":2.0,
-      "examples": [0.1, 0.3, 0.5, 1.0]
+      "maximum": 2.0,
+      "examples": [
+        0.1,
+        0.3,
+        0.5,
+        1.0
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) per circuit.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [1000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "trials": {
       "type": "integer",
       "description": "Number of circuits to generate and measure for the LR-QAOA test.",
       "default": 3,
       "minimum": 1,
-      "examples": [1, 10, 20]
+      "examples": [
+        1,
+        10,
+        20
+      ]
     },
     "num_random_trials": {
       "type": "integer",
       "description": "Number of circuits to generate and measure for the LR-QAOA test.",
       "default": 25,
       "minimum": 10,
-      "examples": [10, 20, 100]
+      "examples": [
+        10,
+        20,
+        100
+      ]
     },
     "confidence_level": {
       "type": "number",
@@ -73,14 +112,25 @@
       "minimum": 0.0,
       "maximum": 1.0,
       "default": 0.995,
-      "examples": [0.995, 0.999]
+      "examples": [
+        0.995,
+        0.999
+      ]
     },
     "seed": {
       "type": "integer",
       "description": "Seed to create the random weights of the weighted maxcut problem. This problem is solve using LR-QAOA",
       "default": 123,
-      "examples": [0, 1, 123]
+      "examples": [
+        0,
+        1,
+        123
+      ]
     }
   },
-  "required": ["benchmark_name","graph_type", "num_qubits"]
+  "required": [
+    "benchmark_name",
+    "graph_type",
+    "num_qubits"
+  ]
 }

--- a/metriq_gym/schemas/mirror_circuits.schema.json
+++ b/metriq_gym/schemas/mirror_circuits.schema.json
@@ -14,7 +14,11 @@
       "type": "integer",
       "description": "Number of qubits to use for the mirror circuit. If not specified, uses all available qubits on the device.",
       "minimum": 2,
-      "examples": [4, 8, 16]
+      "examples": [
+        4,
+        8,
+        16
+      ]
     },
     "num_layers": {
       "type": "integer",
@@ -22,7 +26,11 @@
       "default": 3,
       "minimum": 1,
       "maximum": 500,
-      "examples": [3, 5, 10]
+      "examples": [
+        3,
+        5,
+        10
+      ]
     },
     "two_qubit_gate_prob": {
       "type": "number",
@@ -30,21 +38,27 @@
       "default": 0.5,
       "minimum": 0.0,
       "maximum": 1.0,
-      "examples": [0.3, 0.5, 0.8]
+      "examples": [
+        0.3,
+        0.5,
+        0.8
+      ]
     },
     "two_qubit_gate_name": {
       "type": "string",
       "description": "Type of two-qubit gate to use in the circuit.",
-      "enum": ["CNOT", "CZ"],
+      "enum": [
+        "CNOT",
+        "CZ"
+      ],
       "default": "CNOT",
-      "examples": ["CNOT", "CZ"]
+      "examples": [
+        "CNOT",
+        "CZ"
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) for the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [1000, 5000, 10000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "num_circuits": {
       "type": "integer",
@@ -52,14 +66,24 @@
       "default": 10,
       "minimum": 1,
       "maximum": 1000,
-      "examples": [10, 50, 100]
+      "examples": [
+        10,
+        50,
+        100
+      ]
     },
     "seed": {
       "type": "integer",
       "description": "Optional random seed for reproducible circuit generation. If provided, circuits will be deterministic.",
       "minimum": 0,
-      "examples": [42, 123, 2024]
+      "examples": [
+        42,
+        123,
+        2024
+      ]
     }
   },
-  "required": ["benchmark_name"]
+  "required": [
+    "benchmark_name"
+  ]
 }

--- a/metriq_gym/schemas/phase_estimation.schema.json
+++ b/metriq_gym/schemas/phase_estimation.schema.json
@@ -12,39 +12,25 @@
       "description": "Name of the benchmark. Must be 'Phase Estimation' for this schema."
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [5000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "min_qubits": {
       "type": "integer",
       "description": "Minimum number of qubits to start generating circuits for the benchmark.",
       "default": 3,
       "minimum": 3,
-      "examples": [4]
+      "examples": [
+        4
+      ]
     },
     "max_qubits": {
-      "type": "integer",
-      "description": "Maximum number of qubits to stop generating circuits for the benchmark.",
-      "default": 6,
-      "minimum": 2,
-      "examples": [7]
+      "$ref": "common.schema.json#/$defs/max_qubits"
     },
     "skip_qubits": {
-      "type": "integer",
-      "description": "The step size for generating circuits from the min to max qubit sizes. ",
-      "default": 1,
-      "minimum": 1,
-      "examples": [2]
+      "$ref": "common.schema.json#/$defs/skip_qubits"
     },
     "max_circuits": {
-      "type": "integer",
-      "description": "Maximum number of circuits generated for each qubit size in the benchmark.",
-      "default": 3,
-      "minimum": 1,
-      "examples": [9]
+      "$ref": "common.schema.json#/$defs/max_circuits"
     },
     "method": {
       "type": "integer",
@@ -55,19 +41,26 @@
     "init_phase": {
       "type": "number",
       "description": "Specifies the theta for the benchmark; note that max_circuits must be 1 if this is used.",
-      "examples": [0.125]
+      "examples": [
+        0.125
+      ]
     },
     "use_midcircuit_measurement": {
       "type": "boolean",
       "description": "Creates circuits with mid-circuit measurements.",
       "default": false,
-      "examples": [true]
-
+      "examples": [
+        true
+      ]
     }
   },
-  "required": ["benchmark_name"],
+  "required": [
+    "benchmark_name"
+  ],
   "if": {
-    "required": ["init_phase"]
+    "required": [
+      "init_phase"
+    ]
   },
   "then": {
     "properties": {

--- a/metriq_gym/schemas/qat_ole.schema.json
+++ b/metriq_gym/schemas/qat_ole.schema.json
@@ -2,7 +2,7 @@
   "$id": "metriq-gym/qat_ole.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "QAT OLE",
-  "description": "Quantum Advantage Tracker Operator Loschmidt Echo (OLE) benchmark. Loads an OLE circuit and estimates the Pauli-Z product expectation value ⟨Z_{q_0} ... Z_{q_k}⟩.",
+  "description": "Quantum Advantage Tracker Operator Loschmidt Echo (OLE) benchmark. Loads an OLE circuit and estimates the Pauli-Z product expectation value \u27e8Z_{q_0} ... Z_{q_k}\u27e9.",
   "type": "object",
   "properties": {
     "benchmark_name": {
@@ -13,13 +13,23 @@
     "circuit": {
       "type": "string",
       "description": "Named QAT OLE circuit to fetch from the Quantum Advantage Tracker repository. Mutually exclusive with qasm_path. Uses the known observable qubits [52, 59, 72] for all named circuits.",
-      "enum": ["49Q_L3", "49Q_L6", "70Q_L6"],
-      "examples": ["49Q_L3", "49Q_L6", "70Q_L6"]
+      "enum": [
+        "49Q_L3",
+        "49Q_L6",
+        "70Q_L6"
+      ],
+      "examples": [
+        "49Q_L3",
+        "49Q_L6",
+        "70Q_L6"
+      ]
     },
     "qasm_path": {
       "type": "string",
       "description": "Path to a local OpenQASM 3.0 circuit file, resolved relative to the current working directory. Mutually exclusive with circuit. Requires observable_qubits.",
-      "examples": ["metriq_gym/schemas/examples/qat_ole_small.qasm"]
+      "examples": [
+        "metriq_gym/schemas/examples/qat_ole_small.qasm"
+      ]
     },
     "observable_qubits": {
       "type": "array",
@@ -29,39 +39,67 @@
         "minimum": 0
       },
       "minItems": 1,
-      "examples": [[0, 1, 2], [52, 59, 72]]
+      "examples": [
+        [
+          0,
+          1,
+          2
+        ],
+        [
+          52,
+          59,
+          72
+        ]
+      ]
     },
     "num_initial_states": {
       "type": "integer",
       "description": "Number of randomly sampled computational-basis initial states to average over (N_init in the QAT OLE protocol). The device executes one circuit per initial state.",
       "default": 10,
       "minimum": 1,
-      "examples": [5, 10, 20]
+      "examples": [
+        5,
+        10,
+        20
+      ]
     },
     "seed": {
       "type": "integer",
       "description": "Optional random seed for sampling the initial states, for reproducibility.",
-      "examples": [42]
+      "examples": [
+        42
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots per circuit execution.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [100, 1000, 4096]
+      "$ref": "common.schema.json#/$defs/shots"
     }
   },
-  "required": ["benchmark_name"],
+  "required": [
+    "benchmark_name"
+  ],
   "oneOf": [
     {
       "description": "Named QAT circuit fetched from the Quantum Advantage Tracker.",
-      "required": ["circuit"],
-      "not": { "required": ["qasm_path"] }
+      "required": [
+        "circuit"
+      ],
+      "not": {
+        "required": [
+          "qasm_path"
+        ]
+      }
     },
     {
       "description": "Local QASM file with explicit observable qubits.",
-      "required": ["qasm_path", "observable_qubits"],
-      "not": { "required": ["circuit"] }
+      "required": [
+        "qasm_path",
+        "observable_qubits"
+      ],
+      "not": {
+        "required": [
+          "circuit"
+        ]
+      }
     }
   ]
 }

--- a/metriq_gym/schemas/qml_kernel.schema.json
+++ b/metriq_gym/schemas/qml_kernel.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "metriq-gym/qml_kernel.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",  
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "QML Kernel",
   "description": "The QML Kernel benchmark schema definition, describing parameters for the QML Kernel benchmark.",
   "type": "object",
@@ -14,15 +14,16 @@
       "type": "integer",
       "description": "Number of qubits used in the QML Kernel circuit(s).",
       "minimum": 2,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) for the QML Kernel benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [1000]
+      "$ref": "common.schema.json#/$defs/shots"
     }
   },
-  "required": ["benchmark_name", "num_qubits"]
+  "required": [
+    "benchmark_name",
+    "num_qubits"
+  ]
 }

--- a/metriq_gym/schemas/quantum_fourier_transform.schema.json
+++ b/metriq_gym/schemas/quantum_fourier_transform.schema.json
@@ -12,25 +12,19 @@
       "description": "Name of the benchmark. Must be 'Quantum Fourier Transform' for this schema."
     },
     "shots": {
-      "type": "integer",
-      "description": "Number of measurement shots (repetitions) to use for each circuit in the benchmark.",
-      "default": 1000,
-      "minimum": 1,
-      "examples": [5000]
+      "$ref": "common.schema.json#/$defs/shots"
     },
     "num_qubits": {
       "type": "integer",
       "description": "Number of qubits for the benchmark circuits. A single QFT run uses one fixed qubit count, matching the other benchmarks; sweeps over multiple qubit counts are defined at the suite level.",
       "default": 5,
       "minimum": 2,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "max_circuits": {
-      "type": "integer",
-      "description": "Maximum number of circuits generated for each qubit size in the benchmark.",
-      "default": 3,
-      "minimum": 1,
-      "examples": [9]
+      "$ref": "common.schema.json#/$defs/max_circuits"
     },
     "method": {
       "type": "integer",
@@ -38,24 +32,33 @@
       "default": 1,
       "minimum": 1,
       "maximum": 2,
-      "examples": [2]
+      "examples": [
+        2
+      ]
     },
     "input_value": {
       "type": "integer",
       "description": "Specifies the secret int for the benchmark; note that max_circuits must be 1 if this is used.",
-      "examples": [1]
+      "examples": [
+        1
+      ]
     },
     "use_midcircuit_measurement": {
       "type": "boolean",
       "description": "Creates circuits with mid-circuit measurements.",
       "default": false,
-      "examples": [true]
-
+      "examples": [
+        true
+      ]
     }
   },
-  "required": ["benchmark_name"],
+  "required": [
+    "benchmark_name"
+  ],
   "if": {
-    "required": ["input_value"]
+    "required": [
+      "input_value"
+    ]
   },
   "then": {
     "properties": {

--- a/metriq_gym/schemas/wit.schema.json
+++ b/metriq_gym/schemas/wit.schema.json
@@ -1,29 +1,33 @@
 {
-    "$id": "metriq-gym/wit.schema.json",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "Wormhole-inspired teleportation (WIT)",
-    "description": "The WIT benchmark schema definition, describing the Wormhole-inspired teleportation benchmark configuration.",
-    "type": "object",
-    "properties": {
-      "benchmark_name": {
-        "type": "string",
-        "const": "WIT",
-        "description": "Name of the benchmark. Must be 'WIT' for this schema."
-      },
-      "shots": {
-        "type": "integer",
-        "description": "Number of measurement shots (repetitions) to use for the benchmark.",
-        "default": 1000,
-        "minimum": 1,
-        "examples": [1000]
-      },
-      "num_qubits": {
-        "type": "integer",
-        "description": "Number of qubits to use for the benchmark. Must be either 6 or 7.",
-        "enum": [6, 7],
-        "default": 6,
-        "examples": [6, 7]
-      }
+  "$id": "metriq-gym/wit.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Wormhole-inspired teleportation (WIT)",
+  "description": "The WIT benchmark schema definition, describing the Wormhole-inspired teleportation benchmark configuration.",
+  "type": "object",
+  "properties": {
+    "benchmark_name": {
+      "type": "string",
+      "const": "WIT",
+      "description": "Name of the benchmark. Must be 'WIT' for this schema."
     },
-    "required": ["benchmark_name"]
-  }
+    "shots": {
+      "$ref": "common.schema.json#/$defs/shots"
+    },
+    "num_qubits": {
+      "type": "integer",
+      "description": "Number of qubits to use for the benchmark. Must be either 6 or 7.",
+      "enum": [
+        6,
+        7
+      ],
+      "default": 6,
+      "examples": [
+        6,
+        7
+      ]
+    }
+  },
+  "required": [
+    "benchmark_name"
+  ]
+}

--- a/tests/unit/test_schema_common_defs.py
+++ b/tests/unit/test_schema_common_defs.py
@@ -1,0 +1,56 @@
+"""Benchmark schemas reference common.schema.json rather than restating properties.
+
+Kept out of test_schema_validator.py, which patches JobType module-wide with an
+autouse fixture; these tests need the real job types.
+"""
+
+import glob
+import json
+
+import pytest
+
+from metriq_gym.constants import SCHEMA_MAPPING
+from metriq_gym.schema_validator import (
+    _resolve_refs,
+    create_pydantic_model,
+    load_schema,
+)
+
+COMMON_SCHEMA = "metriq_gym/schemas/common.schema.json"
+
+
+def test_ref_is_materialized_for_the_model_builder():
+    """create_pydantic_model reads field_schema["type"], so refs must be inlined."""
+    shots = load_schema("QML Kernel")["properties"]["shots"]
+    assert "$ref" not in shots
+    assert shots["type"] == "integer"
+    assert shots["default"] == 1000
+
+
+def test_sibling_keywords_override_the_shared_definition():
+    """EPLG defaults to 100 shots; everything else takes the shared 1000."""
+    assert load_schema("EPLG")["properties"]["shots"]["default"] == 100
+    assert load_schema("CLOPS")["properties"]["shots"]["default"] == 1000
+
+
+def test_every_schema_still_builds_a_model():
+    for job_type in SCHEMA_MAPPING:
+        create_pydantic_model(load_schema(job_type.value))
+
+
+def test_unknown_reference_is_rejected():
+    with pytest.raises(ValueError, match="Unknown schema reference"):
+        _resolve_refs({"x": {"$ref": "common.schema.json#/$defs/nope"}}, {})
+
+
+def test_shared_properties_are_referenced_not_restated():
+    """Guards the drift this removed: shots had seven wordings across twelve files."""
+    common = json.load(open(COMMON_SCHEMA))["$defs"]
+    offenders = []
+    for path in sorted(glob.glob("metriq_gym/schemas/*.schema.json")):
+        if path.endswith("common.schema.json"):
+            continue
+        for name, defn in json.load(open(path)).get("properties", {}).items():
+            if name in common and "$ref" not in defn:
+                offenders.append(f"{path}:{name}")
+    assert not offenders, f"restated instead of referenced: {offenders}"


### PR DESCRIPTION
Closes: #424

Twelve schemas each restated the properties they shared. `shots` appeared in all twelve as **seven distinct definitions**, differing only in description wording except for EPLG's `default: 100`. `max_qubits`, `skip_qubits` and `max_circuits` were byte-identical wherever they appeared.

They now reference `common.schema.json`. Keywords written beside a `$ref` override the shared definition, which is how EPLG keeps its own default without forking the property. Every schema already declares draft 2020-12, where `$ref` siblings apply.

## This needed a code change, not just JSON

`create_pydantic_model` reads `field_schema["type"]` directly:

```
create_pydantic_model fails on $ref: KeyError 'type'
```

`jsonschema.validate` resolves references on its own, but the model builder does not, so `load_schema` now materializes them before returning. Both consumers then work on the same fully expanded dict.

## Scope: num_qubits is deliberately excluded

The issue names `num_qubits` as a candidate. It should not be one. It appears in five schemas with five genuinely different definitions:

| schema | definition |
|---|---|
| clops | `default: 10`, `minimum: 1` |
| lr_qaoa | no default, `minimum: 2` |
| qml_kernel | no default, `minimum: 2` |
| quantum_fourier_transform | `default: 5` |
| wit | `default: 6`, `enum: [6, 7]` |

Those are real constraints rather than drift, and sharing them would either loosen validation or change which configs are accepted. `method` is excluded for the same reason: it is constrained to `const: 1` for benchmarks implementing only one variant.

## Verification

No behavioural change. For all twelve schemas I compared every property's `type`, `default`, `minimum`, `maximum`, `enum`, `const`, `pattern` and length constraints, plus the `required` set, before and after resolution: zero differences.

Tests live in `tests/unit/test_schema_common_defs.py` rather than alongside the existing validator tests, which patch `JobType` module-wide with an autouse fixture. They cover reference materialization, the sibling override, model construction for every registered schema, rejection of an unknown reference, and a guard that shared properties stay referenced rather than restated.

Also confirmed a real dispatch still works end to end (`mgym job dispatch wit.example.json -p local -d aer_simulator`), and `common.schema.json` ships under the existing `schemas/*.json` package-data glob.
