### PR TITLE
Replace the argparse.Namespace shim with real parameters

### DIFF
--- a/metriq_gym/benchmarks/benchmark.py
+++ b/metriq_gym/benchmarks/benchmark.py
@@ -1,4 +1,3 @@
-import argparse
 from typing import Iterable, TYPE_CHECKING, Protocol
 from abc import ABC
 
@@ -95,12 +94,7 @@ class BenchmarkResult(BaseModel, ABC):
 
 
 class Benchmark[BD: BenchmarkData, BR: BenchmarkResult]:
-    def __init__(
-        self,
-        args: argparse.Namespace,
-        params: BaseModel,
-    ):
-        self.args = args
+    def __init__(self, params: BaseModel):
         self.params: BaseModel = params
 
     def dispatch_handler(self, device: "QuantumDevice") -> BD:

--- a/metriq_gym/cli.py
+++ b/metriq_gym/cli.py
@@ -13,7 +13,6 @@ Usage overview:
       mgym job upload latest --dry-run
 """
 
-import argparse
 import logging
 from typing import Annotated, Optional
 
@@ -187,13 +186,7 @@ def job_dispatch(
     """Dispatch a benchmark job to a quantum device or simulator."""
     from metriq_gym.run import dispatch_job as _dispatch_job
 
-    args = argparse.Namespace()
-    args.config = config
-    args.provider = provider
-    args.device = device
-
-    job_manager = JobManager()
-    _dispatch_job(args, job_manager)
+    _dispatch_job(config, provider, device, JobManager())
 
 
 @job_app.command("estimate")
@@ -209,12 +202,7 @@ def job_estimate(
     """
     from metriq_gym.run import estimate_job as _estimate_job
 
-    args = argparse.Namespace()
-    args.config = config
-    args.provider = provider
-    args.device = device
-
-    _estimate_job(args)
+    _estimate_job(config, provider, device)
 
 
 @job_app.command("poll")
@@ -241,15 +229,13 @@ def job_poll(
     """Poll job status and retrieve results when complete."""
     from metriq_gym.run import poll_job as _poll_job
 
-    args = argparse.Namespace()
-    args.job_id = job_id
-    args.no_cache = no_cache
-    args.include_raw = include_raw
-    if json_output is not None:
-        args.json = json_output
-
-    job_manager = JobManager()
-    _poll_job(args, job_manager)
+    _poll_job(
+        job_id,
+        JobManager(),
+        json=json_output,
+        no_cache=no_cache,
+        include_raw=include_raw,
+    )
 
 
 @job_app.command("view")
@@ -261,11 +247,7 @@ def job_view(
     """View job details and metadata."""
     from metriq_gym.run import view_job as _view_job
 
-    args = argparse.Namespace()
-    args.job_id = job_id
-
-    job_manager = JobManager()
-    _view_job(args, job_manager)
+    _view_job(job_id, JobManager())
 
 
 @job_app.command("delete")
@@ -279,11 +261,7 @@ def job_delete(
     """
     from metriq_gym.run import delete_job as _delete_job
 
-    args = argparse.Namespace()
-    args.job_id = job_id
-
-    job_manager = JobManager()
-    _delete_job(args, job_manager)
+    _delete_job(job_id, JobManager())
 
 
 @job_app.command("upload")
@@ -363,24 +341,20 @@ def job_upload(
     Failed jobs (dispatch raised, or the provider reported a failure) are uploaded as
     'error' outcome records carrying the captured error message.
     """
-    from metriq_gym.run import upload_job as _upload_job
+    from metriq_gym.run import UploadOptions, upload_job as _upload_job
 
-    args = argparse.Namespace()
-    args.job_id = job_id
-    args.repo = repo
-    args.base_branch = base_branch
-    args.upload_dir = upload_dir
-    args.branch_name = branch_name
-    args.pr_title = pr_title
-    args.pr_body = pr_body
-    args.commit_message = commit_message
-    args.clone_dir = clone_dir
-    args.dry_run = dry_run
-    args.outcome = outcome
-    args.reason = reason
-
-    job_manager = JobManager()
-    _upload_job(args, job_manager)
+    options = UploadOptions(
+        repo=repo,
+        base_branch=base_branch,
+        upload_dir=upload_dir,
+        branch_name=branch_name,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        commit_message=commit_message,
+        clone_dir=clone_dir,
+        dry_run=dry_run,
+    )
+    _upload_job(job_id, JobManager(), outcome=outcome, reason=reason, options=options)
 
 
 @job_app.command("replay")
@@ -451,15 +425,14 @@ def suite_dispatch(
     """Dispatch a suite of benchmark jobs to a quantum device."""
     from metriq_gym.run import dispatch_suite as _dispatch_suite
 
-    args = argparse.Namespace()
-    args.suite_config = suite_config
-    args.provider = provider
-    args.device = device
-    args.components = components
-    args.all_components = all_components
-
-    job_manager = JobManager()
-    _dispatch_suite(args, job_manager)
+    _dispatch_suite(
+        suite_config,
+        provider,
+        device,
+        JobManager(),
+        components=components,
+        all_components=all_components,
+    )
 
 
 @suite_app.command("poll")
@@ -477,14 +450,7 @@ def suite_poll(
     """Poll suite jobs and retrieve results when complete."""
     from metriq_gym.run import poll_suite as _poll_suite
 
-    args = argparse.Namespace()
-    args.suite_id = suite_id
-    args.no_cache = no_cache
-    if json_output is not None:
-        args.json = json_output
-
-    job_manager = JobManager()
-    _poll_suite(args, job_manager)
+    _poll_suite(suite_id, JobManager(), json=json_output, no_cache=no_cache)
 
 
 @suite_app.command("view")
@@ -494,11 +460,7 @@ def suite_view(
     """View jobs in a suite."""
     from metriq_gym.run import view_suite as _view_suite
 
-    args = argparse.Namespace()
-    args.suite_id = suite_id
-
-    job_manager = JobManager()
-    _view_suite(args, job_manager)
+    _view_suite(suite_id, JobManager())
 
 
 @suite_app.command("delete")
@@ -512,11 +474,7 @@ def suite_delete(
     """
     from metriq_gym.run import delete_suite as _delete_suite
 
-    args = argparse.Namespace()
-    args.suite_id = suite_id
-
-    job_manager = JobManager()
-    _delete_suite(args, job_manager)
+    _delete_suite(suite_id, JobManager())
 
 
 @suite_app.command("upload")
@@ -576,19 +534,17 @@ def suite_upload(
     ] = False,
 ) -> None:
     """Upload suite results to GitHub via pull request."""
-    from metriq_gym.run import upload_suite as _upload_suite
+    from metriq_gym.run import UploadOptions, upload_suite as _upload_suite
 
-    args = argparse.Namespace()
-    args.suite_id = suite_id
-    args.repo = repo
-    args.base_branch = base_branch
-    args.upload_dir = upload_dir
-    args.branch_name = branch_name
-    args.pr_title = pr_title
-    args.pr_body = pr_body
-    args.commit_message = commit_message
-    args.clone_dir = clone_dir
-    args.dry_run = dry_run
-
-    job_manager = JobManager()
-    _upload_suite(args, job_manager)
+    options = UploadOptions(
+        repo=repo,
+        base_branch=base_branch,
+        upload_dir=upload_dir,
+        branch_name=branch_name,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        commit_message=commit_message,
+        clone_dir=clone_dir,
+        dry_run=dry_run,
+    )
+    _upload_suite(suite_id, JobManager(), options=options)

--- a/metriq_gym/ionq/device.py
+++ b/metriq_gym/ionq/device.py
@@ -1,0 +1,206 @@
+"""Patches for qBraid's IonQ provider (qbraid >= 0.12, with qiskit-ionq).
+
+Two adjustments make every benchmark receive correctly shaped measurement
+counts without benchmark-specific workarounds:
+
+1. **Native conversion path.** With qiskit-ionq installed, qBraid transpiles
+   qiskit circuits with qiskit's default ``optimization_level=2``, which lays
+   the logical qubits out onto arbitrary physical qubits of the (29-qubit)
+   IonQ backend. Measured bitstrings then no longer line up with the circuit's
+   own qubits (e.g. logical qubit 3 surfaces at physical qubit 28). We convert
+   each circuit to OpenQASM 3 before dispatch, which routes through qBraid's
+   native qasm->ionq path and preserves qubit indices (logical qubit i is
+   bit i of the result).
+
+2. **Count reshaping.** IonQ returns probabilities keyed by integer, which
+   qBraid normalizes to bitstrings whose width is only that of the largest
+   observed value (so a circuit that only ever yields |0..0> and |0..01>
+   reports "0"/"1"). We pad every bitstring to the circuit's qubit count and
+   marginalize onto its classical register, using measurement metadata
+   persisted in the IonQ job at dispatch time.
+
+The dispatch (patch_ionq_device) and poll (patch_ionq_job) sides communicate
+through the IonQ job's ``metadata`` field, which survives across processes, so
+the same reshaping applies whether polling in the dispatching process or a
+later one.
+"""
+
+import json
+import logging
+import types
+from typing import Any
+
+from qiskit import QuantumCircuit
+from qiskit.qasm3 import dumps as qasm3_dumps
+from qbraid.runtime import IonQDevice
+from qbraid.runtime.ionq.job import IonQJob
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData, MeasCount
+
+logger = logging.getLogger(__name__)
+
+# Sentinel so we only patch the IonQJob class once per process.
+_ionq_job_patched = False
+
+# Keys under which per-circuit reshaping metadata is stored in the IonQ job.
+# Each holds a JSON list with one entry per dispatched circuit, in order.
+_META_MEAS_MAPS = "_metriq_meas_maps"
+_META_NUM_QUBITS = "_metriq_num_qubits"
+_META_NUM_CLBITS = "_metriq_num_clbits"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _extract_measurement_map(circuit: QuantumCircuit) -> dict[str, int]:
+    """Return ``{"qubit_index": clbit_index}`` for every measure gate.
+
+    Keys are strings because the map is JSON-serialised into IonQ job
+    metadata (JSON object keys are always strings).
+    """
+    meas_map: dict[str, int] = {}
+    for inst in circuit.data:
+        if inst.operation.name == "measure":
+            q_idx = circuit.find_bit(inst.qubits[0]).index
+            c_idx = circuit.find_bit(inst.clbits[0]).index
+            meas_map[str(q_idx)] = c_idx
+    return meas_map
+
+
+def _pad_counts(counts: MeasCount, num_qubits: int) -> MeasCount:
+    """Zero-pad every bitstring key to *num_qubits* characters."""
+    return {k.zfill(num_qubits): v for k, v in counts.items()}
+
+
+def _marginalize_to_clbits(
+    counts: MeasCount,
+    meas_map: dict[str, int],
+    num_clbits: int,
+) -> MeasCount:
+    """Reduce full-width qubit counts to the circuit's classical register.
+
+    Args:
+        counts: Measurement counts with full-width (num_qubits) bitstring keys.
+        meas_map: ``{"qubit_index": clbit_index}`` extracted at dispatch time.
+        num_clbits: Size of the classical register.
+    """
+    qubit_indices = sorted(int(q) for q in meas_map)
+    clbit_indices = [meas_map[str(q)] for q in qubit_indices]
+
+    marginal: dict[str, int] = {}
+    for bitstring, count in counts.items():
+        width = len(bitstring)
+        clbits = ["0"] * num_clbits
+        for q_idx, c_idx in zip(qubit_indices, clbit_indices):
+            # Bitstrings are big-endian (qubit 0 is the rightmost character),
+            # so qubit q sits at string index (width - 1 - q).
+            clbits[c_idx] = bitstring[width - 1 - q_idx]
+        key = "".join(clbits)
+        marginal[key] = marginal.get(key, 0) + count
+    return marginal
+
+
+def _reshape_counts(
+    counts: MeasCount | list[MeasCount],
+    meas_maps: list[dict[str, int]] | None,
+    num_qubits: list[int] | None,
+    num_clbits: list[int] | None,
+) -> MeasCount | list[MeasCount]:
+    """Pad, then marginalize, each circuit's counts using dispatch metadata.
+
+    ``counts`` is a single dict for a single-circuit job or a list (in circuit
+    dispatch order) for a multi-circuit job. When metadata is absent the counts
+    are returned unchanged.
+    """
+    if num_qubits is None:
+        return counts
+
+    as_list = isinstance(counts, list)
+    counts_list: list[MeasCount] = counts if as_list else [counts]  # type: ignore[assignment]
+
+    reshaped: list[MeasCount] = []
+    for i, circuit_counts in enumerate(counts_list):
+        nq = num_qubits[i] if i < len(num_qubits) else num_qubits[-1]
+        padded = _pad_counts(circuit_counts, nq)
+        if meas_maps is not None and num_clbits is not None:
+            padded = _marginalize_to_clbits(padded, meas_maps[i], num_clbits[i])
+        reshaped.append(padded)
+
+    return reshaped if as_list else reshaped[0]
+
+
+# ── Public patch entry points ──────────────────────────────────────────
+
+
+def patch_ionq_device(device: IonQDevice) -> None:
+    """Patch an IonQDevice instance.
+
+    Converts qiskit circuits to OpenQASM 3 (forcing qBraid's native path) and
+    records per-circuit reshaping metadata on the IonQ job. Also ensures the
+    class-level IonQJob patch is applied so polling reshapes the counts.
+    """
+    patch_ionq_job()  # idempotent
+
+    original_run = IonQDevice.run
+
+    def run_with_patches(self, run_input, *args, **kwargs):
+        is_single = not isinstance(run_input, list)
+        circuits = [run_input] if is_single else list(run_input)
+
+        # Only qiskit circuits need the native-path conversion and reshaping.
+        if all(isinstance(c, QuantumCircuit) for c in circuits):
+            meas_maps = [_extract_measurement_map(c) for c in circuits]
+            num_qubits = [c.num_qubits for c in circuits]
+            num_clbits = [c.num_clbits for c in circuits]
+
+            metadata = dict(kwargs.get("metadata") or {})
+            metadata[_META_MEAS_MAPS] = json.dumps(meas_maps)
+            metadata[_META_NUM_QUBITS] = json.dumps(num_qubits)
+            metadata[_META_NUM_CLBITS] = json.dumps(num_clbits)
+            kwargs["metadata"] = metadata
+
+            converted: list[Any] = [qasm3_dumps(c) for c in circuits]
+            run_input = converted[0] if is_single else converted
+
+        return original_run(self, run_input, *args, **kwargs)
+
+    device.run = types.MethodType(run_with_patches, device)
+
+
+def patch_ionq_job() -> None:
+    """Patch IonQJob.result at the class level (idempotent).
+
+    Wraps qBraid's own ``result`` so it keeps tracking qBraid internals, then
+    pads and marginalizes the counts using the metadata recorded at dispatch.
+    """
+    global _ionq_job_patched  # noqa: PLW0603
+    if _ionq_job_patched:
+        return
+    _ionq_job_patched = True
+
+    original_result = IonQJob.result
+
+    def result_reshaped(self) -> Result:
+        result = original_result(self)
+
+        job_data = self.session.get_job(self.id) or {}
+        metadata = job_data.get("metadata") or {}
+        if _META_NUM_QUBITS not in metadata:
+            return result  # not dispatched through metriq-gym; leave as-is
+
+        meas_maps = json.loads(metadata[_META_MEAS_MAPS]) if _META_MEAS_MAPS in metadata else None
+        num_qubits = json.loads(metadata[_META_NUM_QUBITS])
+        num_clbits = (
+            json.loads(metadata[_META_NUM_CLBITS]) if _META_NUM_CLBITS in metadata else None
+        )
+
+        reshaped = _reshape_counts(result.data.get_counts(), meas_maps, num_qubits, num_clbits)
+        data = GateModelResultData(measurement_counts=reshaped)
+        return Result(
+            device_id=result.device_id,
+            job_id=result.job_id,
+            success=result.success,
+            data=data,
+        )
+
+    IonQJob.result = result_reshaped

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -181,9 +181,9 @@ def setup_device(provider_name: str, device_name: str):
     return device
 
 
-def setup_benchmark(args, params, job_type: JobType) -> "Benchmark":
+def setup_benchmark(params, job_type: JobType) -> "Benchmark":
     reg = _lazy_registry()
-    return reg.BENCHMARK_HANDLERS[job_type](args, params)
+    return reg.BENCHMARK_HANDLERS[job_type](params)
 
 
 def validate_benchmark_device_capacity(params, device) -> None:
@@ -258,7 +258,7 @@ def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
 
     print(f"Dispatching {params.benchmark_name}...")
 
-    handler: Benchmark = setup_benchmark(args, params, job_type)
+    handler: Benchmark = setup_benchmark(params, job_type)
     try:
         job_data: BenchmarkData = handler.dispatch_handler(device)
     except Exception as exc:
@@ -427,7 +427,7 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
                 f"Dispatching {benchmark_entry.name} ({params.benchmark_name}) from {suite.name}..."
             )
 
-            handler: Benchmark = setup_benchmark(args, params, job_type)
+            handler: Benchmark = setup_benchmark(params, job_type)
             try:
                 job_data: BenchmarkData = handler.dispatch_handler(device)
             except Exception as exc:
@@ -992,10 +992,8 @@ def replay_from_debug_file(debug_file: str) -> Optional["BenchmarkResult"]:
         return None
 
     # Create benchmark handler
-    # We need a minimal args namespace for setup_benchmark
-    args = argparse.Namespace()
     validated_params = validate_and_create_model(params)
-    handler: Benchmark = setup_benchmark(args, validated_params, job_type)
+    handler: Benchmark = setup_benchmark(validated_params, job_type)
 
     # Call poll_handler with empty quantum_jobs list
     # Note: CLOPS benchmark uses quantum_jobs for timing, which won't work in replay
@@ -1043,9 +1041,7 @@ def fetch_result(
         return None
 
     job_data: "BenchmarkData" = setup_job_data_class(job_type)(**metriq_job.data)
-    handler: Benchmark = setup_benchmark(
-        args, validate_and_create_model(metriq_job.params), job_type
-    )
+    handler: Benchmark = setup_benchmark(validate_and_create_model(metriq_job.params), job_type)
     from qbraid.runtime import JobStatus
 
     quantum_jobs = [
@@ -1183,7 +1179,7 @@ def estimate_job(args: argparse.Namespace, _job_manager: JobManager | None = Non
             print(f"✗ {job_type.value}: {exc}")
             return
 
-    benchmark: Benchmark = setup_benchmark(args, params, job_type)
+    benchmark: Benchmark = setup_benchmark(params, job_type)
 
     try:
         circuit_batches: list[CircuitBatch] = benchmark.estimate_resources_handler(device)

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -1,6 +1,5 @@
 """Runtime entrypoints for dispatching and managing metriq-gym benchmarks via the CLI."""
 
-import argparse
 from dataclasses import asdict, dataclass
 from datetime import datetime
 import os
@@ -10,7 +9,7 @@ import uuid
 from dotenv import find_dotenv, load_dotenv
 
 from tabulate import tabulate
-from typing import Any, TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING, Optional, cast
 from metriq_gym import __version__
 from metriq_gym.cli import list_jobs, prompt_for_job, app as typer_app
 from metriq_gym.job_manager import JobManager, MetriqGymJob
@@ -37,6 +36,21 @@ logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("metriq_gym")
 
 DEFAULT_UPLOAD_PR_LABELS = ["data", "source:metriq-gym"]
+
+
+@dataclass
+class UploadOptions:
+    """Pull-request options shared by job and suite upload."""
+
+    repo: str | None = None
+    base_branch: str = "main"
+    upload_dir: str | None = None
+    branch_name: str | None = None
+    pr_title: str | None = None
+    pr_body: str | None = None
+    commit_message: str | None = None
+    clone_dir: str | None = None
+    dry_run: bool = False
 
 
 @dataclass
@@ -133,7 +147,7 @@ def _get_device_with_arn_region(provider, device_name: str):
             os.environ["AWS_REGION"] = previous_region
 
 
-def setup_device(provider_name: str, device_name: str):
+def setup_device(provider_name: str | None, device_name: str | None):
     """
     Setup a QBraid device with id device_name from specified provider.
 
@@ -215,7 +229,9 @@ def setup_benchmark_result_class(job_type: JobType) -> type["BenchmarkResult"]:
     return reg.BENCHMARK_RESULT_CLASSES[job_type]
 
 
-def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
+def dispatch_job(
+    config: str, provider: str | None, device_name: str | None, job_manager: JobManager
+) -> None:
     """Dispatch a single benchmark configuration to a quantum device.
 
     Args:
@@ -224,14 +240,16 @@ def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
 
     Note: Continues processing remaining configs if individual configs fail.
     """
-    print(f"Starting dispatch on {args.provider}:{args.device}...")
+    print(f"Starting dispatch on {provider}:{device_name}...")
 
     try:
-        device = setup_device(args.provider, args.device)
+        device = setup_device(provider, device_name)
     except QBraidSetupError:
         return
+    # setup_device rejects a missing provider or device, so both are set here.
+    provider, device_name = cast(str, provider), cast(str, device_name)
 
-    config_file = args.config
+    config_file = config
 
     if not os.path.exists(config_file):
         print(f"✗ {config_file}: Configuration file not found")
@@ -262,14 +280,18 @@ def dispatch_job(args: argparse.Namespace, job_manager: JobManager) -> None:
     try:
         job_data: BenchmarkData = handler.dispatch_handler(device)
     except Exception as exc:
-        job_id = _record_dispatch_failure(job_manager, args, device, job_type, params, exc)
+        job_id = _record_dispatch_failure(
+            job_manager, provider, device_name, device, job_type, params, exc
+        )
         print(f"✗ {params.benchmark_name} failed to dispatch: {type(exc).__name__}: {exc}")
         print(f"  Recorded as failed metriq-gym Job ID: {job_id}")
         print(_OUTCOME_UPLOAD_HINT)
         logger.debug("Dispatch failure traceback", exc_info=True)
         return
 
-    job_id = job_manager.add_job(_new_job(args, device, job_type, params, data=asdict(job_data)))
+    job_id = job_manager.add_job(
+        _new_job(provider, device_name, device, job_type, params, data=asdict(job_data))
+    )
 
     print(f"✓ {params.benchmark_name} dispatched with metriq-gym Job ID: {job_id}")
 
@@ -282,7 +304,8 @@ _OUTCOME_UPLOAD_HINT = (
 
 
 def _new_job(
-    args: argparse.Namespace,
+    provider: str,
+    device_name: str,
     device,
     job_type: JobType,
     params,
@@ -301,11 +324,11 @@ def _new_job(
         job_type=job_type,
         params=params.model_dump(exclude_none=True),
         data=data,
-        provider_name=args.provider,
-        device_name=args.device,
+        provider_name=provider,
+        device_name=device_name,
         platform={
-            "provider": args.provider,
-            "device": args.device,
+            "provider": provider,
+            "device": device_name,
             "device_metadata": normalized_metadata(device),
         },
         dispatch_time=datetime.now(),
@@ -314,7 +337,8 @@ def _new_job(
 
 def _record_dispatch_failure(
     job_manager: JobManager,
-    args: argparse.Namespace,
+    provider: str,
+    device_name: str,
     device,
     job_type: JobType,
     params,
@@ -329,7 +353,8 @@ def _record_dispatch_failure(
     outcome record instead of silently disappearing. No provider job ids exist.
     """
     job = _new_job(
-        args,
+        provider,
+        device_name,
         device,
         job_type,
         params,
@@ -341,7 +366,15 @@ def _record_dispatch_failure(
     return job_manager.add_job(job)
 
 
-def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
+def dispatch_suite(
+    suite_config: str,
+    provider: str | None,
+    device_name: str | None,
+    job_manager: JobManager,
+    *,
+    components: list[str] | None = None,
+    all_components: bool = False,
+) -> None:
     """Dispatch multiple benchmark configurations to a quantum device.
 
     Enables comprehensive device characterization by running the same benchmark
@@ -353,7 +386,7 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
 
     Note: Continues processing remaining configs if individual configs fail.
     """
-    config_file = args.suite_config
+    config_file = suite_config
 
     try:
         suite = parse_suite_file(config_file)
@@ -368,10 +401,9 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
         print(f"✗ {config_file}: No benchmarks found in the suite")
         return
 
-    requested_components = getattr(args, "components", None) or []
+    requested_components = components or []
     if isinstance(requested_components, str):
         requested_components = [requested_components]
-    all_components = getattr(args, "all_components", False)
 
     if requested_components and all_components:
         print("✗ --component and --all cannot be used together")
@@ -395,12 +427,14 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     if all_components and suite.full_suite_warning:
         print(f"WARNING: {suite.full_suite_warning}")
 
-    print(f"Starting suite dispatch on {args.provider}:{args.device}...")
+    print(f"Starting suite dispatch on {provider}:{device_name}...")
 
     try:
-        device = setup_device(args.provider, args.device)
+        device = setup_device(provider, device_name)
     except QBraidSetupError:
         return
+    # setup_device rejects a missing provider or device, so both are set here.
+    provider, device_name = cast(str, provider), cast(str, device_name)
 
     results = []
     successful_jobs = []
@@ -433,7 +467,8 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
             except Exception as exc:
                 job_id = _record_dispatch_failure(
                     job_manager,
-                    args,
+                    provider,
+                    device_name,
                     device,
                     job_type,
                     params,
@@ -450,7 +485,8 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
 
             job_id = job_manager.add_job(
                 _new_job(
-                    args,
+                    provider,
+                    device_name,
                     device,
                     job_type,
                     params,
@@ -486,12 +522,19 @@ def dispatch_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
         print(_OUTCOME_UPLOAD_HINT)
 
 
-def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
-    metriq_job = prompt_for_job(args.job_id, job_manager)
+def poll_job(
+    job_id: str | None,
+    job_manager: JobManager,
+    *,
+    json: str | None = None,
+    no_cache: bool = False,
+    include_raw: bool = False,
+) -> None:
+    metriq_job = prompt_for_job(job_id, job_manager)
     if not metriq_job:
         return
     print("Polling job...")
-    fetch_output = fetch_result(metriq_job, args, job_manager)
+    fetch_output = fetch_result(metriq_job, job_manager, no_cache=no_cache)
     if fetch_output is None:
         if metriq_job.failed:
             print(f"Job {metriq_job.id} failed and has no results.")
@@ -500,7 +543,8 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
             print(f"Job {metriq_job.id} is not yet completed or has no results.")
         return
     export_job_result(
-        args,
+        json,
+        include_raw,
         metriq_job,
         fetch_output.result,
         raw_results=fetch_output.raw_results,
@@ -509,15 +553,14 @@ def poll_job(args: argparse.Namespace, job_manager: JobManager) -> None:
 
 
 def _resolve_upload_outcome(
-    args: argparse.Namespace, metriq_job: MetriqGymJob, has_result: bool
+    raw_outcome: str | None, reason: str | None, metriq_job: MetriqGymJob, has_result: bool
 ) -> tuple[RecordOutcome | None, str | None] | None:
     """Decide which record an upload produces for ``metriq_job``.
 
     Returns ``(outcome, reason)`` where ``outcome`` is None for a completed run, or
     None (after printing why) when nothing should be uploaded.
     """
-    raw_outcome = getattr(args, "outcome", None)
-    reason = (getattr(args, "reason", None) or "").strip() or None
+    reason = (reason or "").strip() or None
 
     outcome: RecordOutcome | None = None
     if raw_outcome is not None:
@@ -565,7 +608,7 @@ def _resolve_upload_outcome(
 
 
 def _fetch_result_for_upload(
-    metriq_job: MetriqGymJob, args: argparse.Namespace, job_manager: JobManager
+    metriq_job: MetriqGymJob, job_manager: JobManager
 ) -> Optional[FetchResultOutput]:
     """``fetch_result`` that degrades gracefully when the provider cannot be reached.
 
@@ -574,7 +617,7 @@ def _fetch_result_for_upload(
     reported as a plain message instead of a traceback so the command fails cleanly.
     """
     try:
-        return fetch_result(metriq_job, args, job_manager)
+        return fetch_result(metriq_job, job_manager)
     except Exception as exc:
         print(
             f"✗ Could not fetch status/results for job {metriq_job.id}: {type(exc).__name__}: {exc}"
@@ -583,46 +626,54 @@ def _fetch_result_for_upload(
         raise
 
 
-def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
+def upload_job(
+    job_id: str | None,
+    job_manager: JobManager,
+    *,
+    outcome: str | None = None,
+    reason: str | None = None,
+    options: UploadOptions | None = None,
+) -> None:
     """Upload a job's results to a GitHub repo by opening a Pull Request.
 
     A job that failed (at dispatch or as reported by the provider) is uploaded as an
     ``outcome: "error"`` record carrying the captured error. ``--outcome unsupported``
     / ``not_applicable`` with ``--reason`` reclassifies such a job by hand.
     """
-    metriq_job = prompt_for_job(args.job_id, job_manager)
+    options = options or UploadOptions()
+    metriq_job = prompt_for_job(job_id, job_manager)
     if not metriq_job:
         return
     print("Preparing job upload...")
     try:
-        fetch_output = _fetch_result_for_upload(metriq_job, args, job_manager)
+        fetch_output = _fetch_result_for_upload(metriq_job, job_manager)
     except Exception:
-        if getattr(args, "outcome", None) is None:
+        if outcome is None:
             return
         # An explicit outcome is a human claim about the attempt; it can still be
         # uploaded when the provider is unreachable (any captured error is attached).
         print("  Continuing with the requested --outcome using the locally recorded job.")
         fetch_output = None
-    resolved = _resolve_upload_outcome(args, metriq_job, has_result=fetch_output is not None)
+    resolved = _resolve_upload_outcome(
+        outcome, reason, metriq_job, has_result=fetch_output is not None
+    )
     if resolved is None:
         return
     outcome, reason = resolved
     result = fetch_output.result if fetch_output is not None else None
 
-    repo = getattr(args, "repo", None)
+    repo = options.repo
     if not repo:
         print("Error: --repo not provided and MGYM_UPLOAD_REPO not set.")
         return
 
-    base_branch = getattr(args, "base_branch", "main")
+    base_branch = options.base_branch
     provider = metriq_job.provider_name
     device = metriq_job.device_name
     # Default upload dir: <root>/v<major.minor>/<provider>/<device>
-    upload_dir = getattr(args, "upload_dir", None) or default_upload_dir(
-        __version__, provider, device
-    )
-    branch_name = getattr(args, "branch_name", None)
-    pr_title = getattr(args, "pr_title", None)
+    upload_dir = options.upload_dir or default_upload_dir(__version__, provider, device)
+    branch_name = options.branch_name
+    pr_title = options.pr_title
     if outcome is not None:
         suffix = f"({outcome.value})"
         if pr_title is None:
@@ -630,10 +681,10 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         elif not pr_title.endswith(suffix):
             pr_title = f"{pr_title} {suffix}"
         print(f"Uploading as '{outcome.value}' outcome record (no results).")
-    pr_body = getattr(args, "pr_body", None)
-    commit_message = getattr(args, "commit_message", None)
-    clone_dir = getattr(args, "clone_dir", None)
-    dry_run = getattr(args, "dry_run", False)
+    pr_body = options.pr_body
+    commit_message = options.commit_message
+    clone_dir = options.clone_dir
+    dry_run = options.dry_run
 
     # Write this job's record to a dedicated JSON file in the target directory
     from metriq_gym.exporters.dict_exporter import DictExporter
@@ -671,18 +722,24 @@ def upload_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         print(f"✗ Upload failed: {e}")
 
 
-def poll_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
-    if not args.suite_id:
+def poll_suite(
+    suite_id: str | None,
+    job_manager: JobManager,
+    *,
+    json: str | None = None,
+    no_cache: bool = False,
+) -> None:
+    if not suite_id:
         print("Suite ID is required to poll suite results.")
         return
-    jobs = job_manager.get_jobs_by_suite_id(args.suite_id)
+    jobs = job_manager.get_jobs_by_suite_id(suite_id)
     if not jobs:
-        print(f"No jobs found for suite ID {args.suite_id}.")
+        print(f"No jobs found for suite ID {suite_id}.")
         return
     completed_jobs: list[MetriqGymJob] = []
     results: list[Any] = []
     for metriq_job in jobs:
-        fetch_output = fetch_result(metriq_job, args, job_manager)
+        fetch_output = fetch_result(metriq_job, job_manager, no_cache=no_cache)
         if fetch_output is None:
             if metriq_job.failed:
                 # Failed jobs have nothing to tabulate; report and keep going so one
@@ -693,7 +750,7 @@ def poll_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
             return
         completed_jobs.append(metriq_job)
         results.append(fetch_output.result)
-    export_suite_results(args, completed_jobs, results)
+    export_suite_results(json, completed_jobs, results)
 
 
 def _get_nested(mapping: dict[str, Any], path: tuple[str, ...]) -> Any | None:
@@ -713,7 +770,9 @@ def print_selected(d, selected_keys):
             print(f"{label}: {value}")
 
 
-def export_suite_results(args, jobs: list[MetriqGymJob], results: list["BenchmarkResult"]) -> None:
+def export_suite_results(
+    json_path: str | None, jobs: list[MetriqGymJob], results: list["BenchmarkResult"]
+) -> None:
     if not jobs:
         return
 
@@ -723,7 +782,7 @@ def export_suite_results(args, jobs: list[MetriqGymJob], results: list["Benchmar
     for job, result in zip(jobs, results):
         records.append(DictExporter(job, result).export() | {"params": job.params})
 
-    if hasattr(args, "json"):
+    if json_path is not None:
         raise NotImplementedError("JSON export of suite results is not implemented yet.")
     else:
         print("\n--- Suite Metadata ---")
@@ -732,17 +791,23 @@ def export_suite_results(args, jobs: list[MetriqGymJob], results: list["Benchmar
         print(tabulate_job_results(records))
 
 
-def upload_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
+def upload_suite(
+    suite_id: str | None,
+    job_manager: JobManager,
+    *,
+    options: UploadOptions | None = None,
+) -> None:
     """Upload all jobs in a suite as a single JSON (array of job records) in one PR."""
-    if not args.suite_id:
+    options = options or UploadOptions()
+    if not suite_id:
         print("Suite ID is required to upload suite results.")
         return
-    jobs = job_manager.get_jobs_by_suite_id(args.suite_id)
+    jobs = job_manager.get_jobs_by_suite_id(suite_id)
     if not jobs:
-        print(f"No jobs found for suite ID {args.suite_id}.")
+        print(f"No jobs found for suite ID {suite_id}.")
         return
 
-    repo = getattr(args, "repo", None)
+    repo = options.repo
     if not repo:
         print("Error: --repo not provided and MGYM_UPLOAD_REPO not set.")
         return
@@ -753,7 +818,7 @@ def upload_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     results: list[Any] = []
     for metriq_job in jobs:
         try:
-            fetch_output = _fetch_result_for_upload(metriq_job, args, job_manager)
+            fetch_output = _fetch_result_for_upload(metriq_job, job_manager)
         except Exception:
             return
         if fetch_output is None:
@@ -777,21 +842,17 @@ def upload_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
     device = jobs[0].device_name
     suite_name = jobs[0].suite_name
 
-    base_branch = getattr(args, "base_branch", "main")
-    upload_dir = getattr(args, "upload_dir", None) or default_upload_dir(
-        __version__, provider, device
-    )
-    branch_name = getattr(args, "branch_name", None) or f"mgym/upload-suite-{args.suite_id}"
+    base_branch = options.base_branch
+    upload_dir = options.upload_dir or default_upload_dir(__version__, provider, device)
+    branch_name = options.branch_name or f"mgym/upload-suite-{suite_id}"
     # Prefer suite name; avoid falling back to suite_id in the title
     suite_label = suite_name or "unnamed"
-    pr_title = getattr(args, "pr_title", None) or (
-        f"mgym upload: suite {suite_label} on {provider}/{device}"
-    )
-    pr_body = getattr(args, "pr_body", None)
+    pr_title = options.pr_title or (f"mgym upload: suite {suite_label} on {provider}/{device}")
+    pr_body = options.pr_body
     # Default commit message aligns with PR title to make browser compare pre-fill useful
-    commit_message = getattr(args, "commit_message", None) or pr_title
-    clone_dir = getattr(args, "clone_dir", None)
-    dry_run = getattr(args, "dry_run", False)
+    commit_message = options.commit_message or pr_title
+    clone_dir = options.clone_dir
+    dry_run = options.dry_run
 
     try:
         from metriq_gym.exporters.github_pr_exporter import GitHubPRExporter
@@ -856,7 +917,8 @@ def tabulate_job_results(records, sep=" +/- "):
 
 
 def export_job_result(
-    args: argparse.Namespace,
+    json_path: str | None,
+    include_raw: bool,
     metriq_job: MetriqGymJob,
     result: "BenchmarkResult",
     raw_results: list["GateModelResultData"] | None = None,
@@ -871,21 +933,20 @@ def export_job_result(
         raw_results: Optional raw measurement counts for debugging.
         from_cache: Whether result was loaded from cache (raw counts unavailable).
     """
-    include_raw = getattr(args, "include_raw", False)
     if include_raw and from_cache:
         print(
             "Warning: --include-raw requested but results are from cache. "
             "Raw counts not available. Use --no-cache to refetch from provider."
         )
 
-    if hasattr(args, "json"):
+    if json_path is not None:
         from metriq_gym.exporters.json_exporter import JsonExporter
 
-        JsonExporter(metriq_job, result).export(args.json)
+        JsonExporter(metriq_job, result).export(json_path)
 
         # Write raw debug data to separate file if requested
         if include_raw and raw_results is not None:
-            _export_raw_debug_data(args.json, metriq_job, raw_results)
+            _export_raw_debug_data(json_path, metriq_job, raw_results)
     else:
         from metriq_gym.exporters.cli_exporter import CliExporter
 
@@ -1008,7 +1069,7 @@ def replay_from_debug_file(debug_file: str) -> Optional["BenchmarkResult"]:
 
 
 def fetch_result(
-    metriq_job: MetriqGymJob, args: argparse.Namespace, job_manager: JobManager
+    metriq_job: MetriqGymJob, job_manager: JobManager, *, no_cache: bool = False
 ) -> Optional[FetchResultOutput]:
     """Fetch benchmark results, optionally including raw measurement counts.
 
@@ -1023,16 +1084,14 @@ def fetch_result(
     """
     job_type: JobType = JobType(metriq_job.job_type)
     job_result_type = setup_benchmark_result_class(job_type)
-    if metriq_job.result_data is not None and not getattr(args, "no_cache", False):
+    if metriq_job.result_data is not None and not no_cache:
         print("[Cached result data]")
         cached_result = job_result_type.model_validate(metriq_job.result_data)
         return FetchResultOutput(result=cached_result, raw_results=None, from_cache=True)
 
     has_provider_jobs = bool(metriq_job.data.get("provider_job_ids"))
     # ``getattr``: tests pass lightweight job stand-ins without the failure fields.
-    if getattr(metriq_job, "failed", False) and (
-        not has_provider_jobs or not getattr(args, "no_cache", False)
-    ):
+    if getattr(metriq_job, "failed", False) and (not has_provider_jobs or not no_cache):
         # Failed/cancelled provider statuses are terminal, so the recorded failure is
         # trusted without reconnecting to the provider (``--no-cache`` forces a
         # re-poll). A dispatch failure has nothing to poll at all.
@@ -1092,26 +1151,26 @@ def fetch_result(
         return None
 
 
-def view_job(args: argparse.Namespace, job_manager: JobManager) -> None:
-    metriq_job = prompt_for_job(args.job_id, job_manager)
+def view_job(job_id: str | None, job_manager: JobManager) -> None:
+    metriq_job = prompt_for_job(job_id, job_manager)
     if metriq_job:
         print(metriq_job)
 
 
-def view_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
-    if not args.suite_id:
+def view_suite(suite_id: str | None, job_manager: JobManager) -> None:
+    if not suite_id:
         print("Suite ID is required to view suite jobs.")
         return
-    jobs = job_manager.get_jobs_by_suite_id(args.suite_id)
+    jobs = job_manager.get_jobs_by_suite_id(suite_id)
     if not jobs:
-        print(f"No jobs found for suite ID {args.suite_id}.")
+        print(f"No jobs found for suite ID {suite_id}.")
         return
-    print(f"Jobs for suite ID {args.suite_id}:")
+    print(f"Jobs for suite ID {suite_id}:")
     list_jobs(jobs, show_index=False, show_suite_id=False)
 
 
-def delete_job(args: argparse.Namespace, job_manager: JobManager) -> None:
-    metriq_job = prompt_for_job(args.job_id, job_manager)
+def delete_job(job_id: str | None, job_manager: JobManager) -> None:
+    metriq_job = prompt_for_job(job_id, job_manager)
     if metriq_job:
         try:
             job_manager.delete_job(metriq_job.id)
@@ -1124,13 +1183,13 @@ def delete_job(args: argparse.Namespace, job_manager: JobManager) -> None:
         print("No job selected for deletion.")
 
 
-def delete_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
-    if not args.suite_id:
+def delete_suite(suite_id: str | None, job_manager: JobManager) -> None:
+    if not suite_id:
         print("Suite ID is required to delete suite jobs.")
         return
-    jobs = job_manager.get_jobs_by_suite_id(args.suite_id)
+    jobs = job_manager.get_jobs_by_suite_id(suite_id)
     if not jobs:
-        print(f"No jobs found for suite ID {args.suite_id}.")
+        print(f"No jobs found for suite ID {suite_id}.")
         return
     for job in jobs:
         try:
@@ -1138,24 +1197,29 @@ def delete_suite(args: argparse.Namespace, job_manager: JobManager) -> None:
             print(f"Job {job.id} deleted successfully.")
         except Exception as e:
             print(f"Failed to delete job {job.id}: {e}")
-    print(f"All jobs for suite ID {args.suite_id} deleted successfully.")
+    print(f"All jobs for suite ID {suite_id} deleted successfully.")
 
 
-def estimate_job(args: argparse.Namespace, _job_manager: JobManager | None = None) -> None:
-    if not args.provider:
+def estimate_job(
+    config: str,
+    provider: str | None,
+    device_name: str | None,
+    _job_manager: JobManager | None = None,
+) -> None:
+    if not provider:
         print("Provider is required for resource estimation.")
         return
 
     device = None
-    if args.device:
+    if device:
         try:
-            device = setup_device(args.provider, args.device)
+            device = setup_device(provider, device_name)
         except QBraidSetupError:
             return
     else:
         print("No device specified; estimating resources without device-specific topology.")
 
-    config_file = args.config
+    config_file = config
 
     if not os.path.exists(config_file):
         print(f"✗ {config_file}: Configuration file not found")
@@ -1193,7 +1257,7 @@ def estimate_job(args: argparse.Namespace, _job_manager: JobManager | None = Non
         print(f"✗ Failed to estimate resources: {exc}")
         return
 
-    print_resource_estimate(job_type, args.provider, args.device, resource_estimate)
+    print_resource_estimate(job_type, provider, device, resource_estimate)
 
 
 def main() -> int:

--- a/tests/unit/benchmarks/test_clops.py
+++ b/tests/unit/benchmarks/test_clops.py
@@ -55,7 +55,7 @@ def _make_params(**overrides):
 def _make_clops(**param_overrides) -> Clops:
     args = argparse.Namespace()
     params = _make_params(**param_overrides)
-    return Clops(args, params)
+    return Clops(params)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/benchmarks/test_clops.py
+++ b/tests/unit/benchmarks/test_clops.py
@@ -1,6 +1,5 @@
 """Unit tests for CLOPS benchmark circuit construction and dispatch modes."""
 
-import argparse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -53,7 +52,6 @@ def _make_params(**overrides):
 
 
 def _make_clops(**param_overrides) -> Clops:
-    args = argparse.Namespace()
     params = _make_params(**param_overrides)
     return Clops(params)
 

--- a/tests/unit/benchmarks/test_eplg.py
+++ b/tests/unit/benchmarks/test_eplg.py
@@ -135,4 +135,4 @@ def test_eplg_warns_when_device_gate_support_cannot_be_confirmed():
             match="provider/device-specific.*change them to a native universal gate set",
         ),
     ):
-        EPLG(MagicMock(), params)._build_circuits(MagicMock())
+        EPLG(params)._build_circuits(MagicMock())

--- a/tests/unit/benchmarks/test_gate_counts.py
+++ b/tests/unit/benchmarks/test_gate_counts.py
@@ -112,7 +112,7 @@ class TestEPLGGateCounts:
         device = MagicMock()
         device.run.return_value = mock_job
 
-        result = EPLG(MagicMock(), params).dispatch_handler(device)
+        result = EPLG(params).dispatch_handler(device)
 
         assert isinstance(result, EPLGData)
         assert result.input_two_qubit_gate_counts == [1]
@@ -150,7 +150,7 @@ class TestEPLGGateCounts:
         device = MagicMock()
         device.run.return_value = mock_job
 
-        result = EPLG(MagicMock(), params).dispatch_handler(device)
+        result = EPLG(params).dispatch_handler(device)
 
         # Without local transpilation the submitted circuits are the logical ones.
         assert result.input_two_qubit_gate_counts == [2]
@@ -179,7 +179,7 @@ class TestClopsGateCounts:
         device = MagicMock()
         device.run.return_value = mock_job
 
-        result = Clops(MagicMock(), params).dispatch_handler(device)
+        result = Clops(params).dispatch_handler(device)
 
         assert isinstance(result, ClopsData)
         assert result.input_two_qubit_gate_counts == [4, 4]

--- a/tests/unit/benchmarks/test_lr-qaoa.py
+++ b/tests/unit/benchmarks/test_lr-qaoa.py
@@ -18,10 +18,7 @@ from metriq_gym.exceptions import DeviceCapacityError
 
 
 def test_lr_qaoa_rejects_oversized_workload_before_connectivity_lookup():
-    benchmark = LinearRampQAOA(
-        SimpleNamespace(),
-        SimpleNamespace(num_qubits=50),
-    )
+    benchmark = LinearRampQAOA(SimpleNamespace(num_qubits=50))
     device = SimpleNamespace(
         id="arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1",
         num_qubits=36,

--- a/tests/unit/benchmarks/test_mirror_circuits.py
+++ b/tests/unit/benchmarks/test_mirror_circuits.py
@@ -298,13 +298,11 @@ class TestMirrorCircuitsBenchmark:
 
     @pytest.fixture
     def benchmark(self, mock_params):
-        args = MagicMock()
-        return MirrorCircuits(args, mock_params)
+        return MirrorCircuits(mock_params)
 
     @pytest.fixture
     def benchmark_minimal(self, mock_params_minimal):
-        args = MagicMock()
-        return MirrorCircuits(args, mock_params_minimal)
+        return MirrorCircuits(mock_params_minimal)
 
     @patch("metriq_gym.benchmarks.mirror_circuits.connectivity_graph")
     @patch("metriq_gym.benchmarks.mirror_circuits.generate_mirror_circuit")
@@ -360,7 +358,7 @@ class TestMirrorCircuitsBenchmark:
         mock_params_with_width.seed = 42
         mock_params_with_width.width = 2
 
-        benchmark_with_width = MirrorCircuits(MagicMock(), mock_params_with_width)
+        benchmark_with_width = MirrorCircuits(mock_params_with_width)
 
         mock_generate_circuit.reset_mock()
 
@@ -382,7 +380,7 @@ class TestMirrorCircuitsBenchmark:
         mock_params_invalid.seed = 42
         mock_params_invalid.width = 10
 
-        benchmark_invalid = MirrorCircuits(MagicMock(), mock_params_invalid)
+        benchmark_invalid = MirrorCircuits(mock_params_invalid)
 
         with pytest.raises(ValueError, match="exceeds device capacity"):
             benchmark_invalid.dispatch_handler(mock_device)

--- a/tests/unit/quantinuum/test_run_fetch_result_quantinuum.py
+++ b/tests/unit/quantinuum/test_run_fetch_result_quantinuum.py
@@ -72,8 +72,6 @@ def test_fetch_result_returns_handler_result_for_quantinuum(monkeypatch):
     # Job manager with no-op update
     mgr = types.SimpleNamespace(update_job=lambda *_: None)
 
-    # Create args with include_raw=False to avoid serialization issues with mocks
-    args = types.SimpleNamespace(include_raw=False, no_cache=False)
-    fetch_output = runmod.fetch_result(mjob, args, mgr)
+    fetch_output = runmod.fetch_result(mjob, mgr, no_cache=False)
     assert fetch_output.result.model_dump()["expectation_value"] == 0.2
     assert fetch_output.from_cache is False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -164,7 +164,10 @@ def test_job_poll_include_raw_flag():
     runner = CliRunner()
 
     with patch("metriq_gym.cli.JobManager") as mock_jm_class:
-        with patch("metriq_gym.run.fetch_result") as mock_fetch:
+        with (
+            patch("metriq_gym.run.fetch_result") as mock_fetch,
+            patch("metriq_gym.run.export_job_result") as mock_export,
+        ):
             # Setup mock job manager
             mock_jm = MagicMock()
             mock_jm_class.return_value = mock_jm
@@ -181,10 +184,9 @@ def test_job_poll_include_raw_flag():
             # Run CLI with --include-raw
             runner.invoke(app, ["job", "poll", "latest", "--include-raw"])
 
-            # Verify fetch_result was called with args that have include_raw=True
+            # include_raw is consumed by export_job_result, not fetch_result
             assert mock_fetch.called
-            args = mock_fetch.call_args[0][1]  # Second positional arg is args
-            assert args.include_raw is True
+            assert mock_export.call_args[0][1] is True
 
 
 REPLAY_DEBUG_DATA = {

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -89,10 +89,9 @@ class TestJobCommands:
         # The command should attempt to call dispatch_job
         # (may fail due to config validation, but the call is made)
         mock_dispatch.assert_called_once()
-        args = mock_dispatch.call_args[0][0]
-        assert args.config == str(config_file)
-        assert args.provider == "local"
-        assert args.device == "aer_simulator"
+        assert mock_dispatch.call_args[0][0] == str(config_file)
+        assert mock_dispatch.call_args[0][1] == "local"
+        assert mock_dispatch.call_args[0][2] == "aer_simulator"
 
     def test_job_poll_help(self):
         """mgym job poll --help should show usage."""
@@ -109,9 +108,8 @@ class TestJobCommands:
         runner.invoke(app, ["job", "poll", "latest"])
 
         mock_poll.assert_called_once()
-        args = mock_poll.call_args[0][0]
-        assert args.job_id == "latest"
-        assert args.no_cache is False
+        assert mock_poll.call_args[0][0] == "latest"
+        assert mock_poll.call_args[1]["no_cache"] is False
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.poll_job")
@@ -121,8 +119,7 @@ class TestJobCommands:
         runner.invoke(app, ["job", "poll", "latest", "--json", str(outfile)])
 
         mock_poll.assert_called_once()
-        args = mock_poll.call_args[0][0]
-        assert args.json == str(outfile)
+        assert mock_poll.call_args[1]["json"] == str(outfile)
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.poll_job")
@@ -131,8 +128,7 @@ class TestJobCommands:
         runner.invoke(app, ["job", "poll", "latest", "--no-cache"])
 
         mock_poll.assert_called_once()
-        args = mock_poll.call_args[0][0]
-        assert args.no_cache is True
+        assert mock_poll.call_args[1]["no_cache"] is True
 
     def test_job_view_help(self):
         """mgym job view --help should show usage."""
@@ -147,8 +143,7 @@ class TestJobCommands:
         runner.invoke(app, ["job", "view", "test-job-id"])
 
         mock_view.assert_called_once()
-        args = mock_view.call_args[0][0]
-        assert args.job_id == "test-job-id"
+        assert mock_view.call_args[0][0] == "test-job-id"
 
     def test_job_delete_help(self):
         """mgym job delete --help should show usage."""
@@ -163,8 +158,7 @@ class TestJobCommands:
         runner.invoke(app, ["job", "delete", "test-job-id"])
 
         mock_delete.assert_called_once()
-        args = mock_delete.call_args[0][0]
-        assert args.job_id == "test-job-id"
+        assert mock_delete.call_args[0][0] == "test-job-id"
 
     def test_job_estimate_help(self):
         """mgym job estimate --help should show usage."""
@@ -197,11 +191,10 @@ class TestJobCommands:
         runner.invoke(app, ["job", "upload", "latest", "--dry-run"])
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.job_id == "latest"
-        assert args.dry_run is True
-        assert args.outcome is None
-        assert args.reason is None
+        assert mock_upload.call_args[0][0] == "latest"
+        assert mock_upload.call_args[1]["options"].dry_run is True
+        assert mock_upload.call_args[1]["outcome"] is None
+        assert mock_upload.call_args[1]["reason"] is None
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -221,9 +214,8 @@ class TestJobCommands:
         )
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.outcome == "unsupported"
-        assert args.reason == "Compiler rejects 100q circuits"
+        assert mock_upload.call_args[1]["outcome"] == "unsupported"
+        assert mock_upload.call_args[1]["reason"] == "Compiler rejects 100q circuits"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -232,7 +224,7 @@ class TestJobCommands:
             app, ["job", "upload", "test-id", "--outcome", "Not_Applicable", "--reason", "r"]
         )
         mock_upload.assert_called_once()
-        assert mock_upload.call_args[0][0].outcome == "not_applicable"
+        assert mock_upload.call_args[1]["outcome"] == "not_applicable"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -274,17 +266,16 @@ class TestJobCommands:
         )
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.job_id == "test-id"
-        assert args.repo == "owner/repo"
-        assert args.base_branch == "develop"
-        assert args.upload_dir == "data/results"
-        assert args.branch_name == "feature-branch"
-        assert args.pr_title == "My PR"
-        assert args.pr_body == "PR description"
-        assert args.commit_message == "Add results"
-        assert args.clone_dir == "/tmp/clone"
-        assert args.dry_run is True
+        assert mock_upload.call_args[0][0] == "test-id"
+        assert mock_upload.call_args[1]["options"].repo == "owner/repo"
+        assert mock_upload.call_args[1]["options"].base_branch == "develop"
+        assert mock_upload.call_args[1]["options"].upload_dir == "data/results"
+        assert mock_upload.call_args[1]["options"].branch_name == "feature-branch"
+        assert mock_upload.call_args[1]["options"].pr_title == "My PR"
+        assert mock_upload.call_args[1]["options"].pr_body == "PR description"
+        assert mock_upload.call_args[1]["options"].commit_message == "Add results"
+        assert mock_upload.call_args[1]["options"].clone_dir == "/tmp/clone"
+        assert mock_upload.call_args[1]["options"].dry_run is True
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -293,10 +284,9 @@ class TestJobCommands:
         runner.invoke(app, ["job", "upload", "latest"])
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.repo == "unitaryfoundation/metriq-data"
-        assert args.base_branch == "main"
-        assert args.dry_run is False
+        assert mock_upload.call_args[1]["options"].repo == "unitaryfoundation/metriq-data"
+        assert mock_upload.call_args[1]["options"].base_branch == "main"
+        assert mock_upload.call_args[1]["options"].dry_run is False
 
 
 class TestSuiteCommands:
@@ -363,12 +353,11 @@ class TestSuiteCommands:
         )
 
         mock_dispatch.assert_called_once()
-        args = mock_dispatch.call_args[0][0]
-        assert args.suite_config == str(config_file)
-        assert args.provider == "local"
-        assert args.device == "aer_simulator"
-        assert args.components == ["qft", "wit"]
-        assert args.all_components is False
+        assert mock_dispatch.call_args[0][0] == str(config_file)
+        assert mock_dispatch.call_args[0][1] == "local"
+        assert mock_dispatch.call_args[0][2] == "aer_simulator"
+        assert mock_dispatch.call_args[1]["components"] == ["qft", "wit"]
+        assert mock_dispatch.call_args[1]["all_components"] is False
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.dispatch_suite")
@@ -382,9 +371,8 @@ class TestSuiteCommands:
         )
 
         mock_dispatch.assert_called_once()
-        args = mock_dispatch.call_args[0][0]
-        assert args.components is None
-        assert args.all_components is True
+        assert mock_dispatch.call_args[1]["components"] is None
+        assert mock_dispatch.call_args[1]["all_components"] is True
 
     def test_suite_poll_help(self):
         """mgym suite poll --help should show usage."""
@@ -401,8 +389,7 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "poll", "test-suite-id"])
 
         mock_poll.assert_called_once()
-        args = mock_poll.call_args[0][0]
-        assert args.suite_id == "test-suite-id"
+        assert mock_poll.call_args[0][0] == "test-suite-id"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.poll_suite")
@@ -412,10 +399,9 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "poll", "test-suite", "--json", str(outfile), "--no-cache"])
 
         mock_poll.assert_called_once()
-        args = mock_poll.call_args[0][0]
-        assert args.suite_id == "test-suite"
-        assert args.json == str(outfile)
-        assert args.no_cache is True
+        assert mock_poll.call_args[0][0] == "test-suite"
+        assert mock_poll.call_args[1]["json"] == str(outfile)
+        assert mock_poll.call_args[1]["no_cache"] is True
 
     def test_suite_view_help(self):
         """mgym suite view --help should show usage."""
@@ -430,8 +416,7 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "view", "test-suite-id"])
 
         mock_view.assert_called_once()
-        args = mock_view.call_args[0][0]
-        assert args.suite_id == "test-suite-id"
+        assert mock_view.call_args[0][0] == "test-suite-id"
 
     def test_suite_delete_help(self):
         """mgym suite delete --help should show usage."""
@@ -446,8 +431,7 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "delete", "test-suite-id"])
 
         mock_delete.assert_called_once()
-        args = mock_delete.call_args[0][0]
-        assert args.suite_id == "test-suite-id"
+        assert mock_delete.call_args[0][0] == "test-suite-id"
 
     def test_suite_upload_help(self):
         """mgym suite upload --help should show all options."""
@@ -464,9 +448,8 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "upload", "test-suite", "--dry-run"])
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.suite_id == "test-suite"
-        assert args.dry_run is True
+        assert mock_upload.call_args[0][0] == "test-suite"
+        assert mock_upload.call_args[1]["options"].dry_run is True
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_suite")
@@ -475,10 +458,9 @@ class TestSuiteCommands:
         runner.invoke(app, ["suite", "upload", "test-suite"])
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.repo == "unitaryfoundation/metriq-data"
-        assert args.base_branch == "main"
-        assert args.dry_run is False
+        assert mock_upload.call_args[1]["options"].repo == "unitaryfoundation/metriq-data"
+        assert mock_upload.call_args[1]["options"].base_branch == "main"
+        assert mock_upload.call_args[1]["options"].dry_run is False
 
 
 class TestEnvironmentVariables:
@@ -493,8 +475,7 @@ class TestEnvironmentVariables:
         runner.invoke(app, ["job", "upload", "latest"], env={"MGYM_UPLOAD_REPO": "custom/repo"})
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.repo == "custom/repo"
+        assert mock_upload.call_args[1]["options"].repo == "custom/repo"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -507,8 +488,7 @@ class TestEnvironmentVariables:
         )
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.base_branch == "develop"
+        assert mock_upload.call_args[1]["options"].base_branch == "develop"
 
     @patch("metriq_gym.cli.JobManager")
     @patch("metriq_gym.run.upload_job")
@@ -521,8 +501,7 @@ class TestEnvironmentVariables:
         )
 
         mock_upload.assert_called_once()
-        args = mock_upload.call_args[0][0]
-        assert args.repo == "cli/repo"
+        assert mock_upload.call_args[1]["options"].repo == "cli/repo"
 
 
 class TestPromptForJob:

--- a/tests/unit/test_record_outcomes.py
+++ b/tests/unit/test_record_outcomes.py
@@ -20,6 +20,7 @@ from metriq_gym.constants import JobType, RecordOutcome
 from metriq_gym.exporters.dict_exporter import DictExporter
 from metriq_gym.job_manager import JobManager, MetriqGymJob
 from metriq_gym.run import (
+    UploadOptions,
     _resolve_upload_outcome,
     dispatch_job,
     fetch_result,
@@ -193,9 +194,8 @@ def test_fetch_result_records_provider_failure_on_job(monkeypatch, tmp_path, cap
     monkeypatch.setattr(
         "metriq_gym.run.failed_jobs_summary", lambda qjobs: "pj-1: FAILED - compilation failed"
     )
-    args = SimpleNamespace(no_cache=False, include_raw=False)
 
-    assert fetch_result(job, args, jm) is None
+    assert fetch_result(job, jm) is None
 
     assert job.error["source"] == "poll"
     assert job.error["message"] == "pj-1: FAILED - compilation failed"
@@ -215,9 +215,8 @@ def test_fetch_result_pending_job_does_not_record_error(monkeypatch, tmp_path, c
         "metriq_gym.run.job_status",
         lambda task: SimpleNamespace(status=JobStatus.QUEUED, queue_position=None),
     )
-    args = SimpleNamespace(no_cache=False, include_raw=False)
 
-    assert fetch_result(job, args, jm) is None
+    assert fetch_result(job, jm) is None
     assert job.error is None
     assert "not yet completed" in capsys.readouterr().out
 
@@ -231,9 +230,8 @@ def test_fetch_result_short_circuits_dispatch_failure(monkeypatch, tmp_path, cap
     jm.add_job(job)
     load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
     _patch_fetch(monkeypatch, load_job)
-    args = SimpleNamespace(no_cache=False, include_raw=False)
 
-    assert fetch_result(job, args, jm) is None
+    assert fetch_result(job, jm) is None
     assert "Job failed at dispatch" in capsys.readouterr().out
     load_job.assert_not_called()
 
@@ -260,8 +258,7 @@ def test_dispatch_job_records_failed_attempt(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr("metriq_gym.run.setup_benchmark", lambda *_, **__: handler)
     monkeypatch.setattr("metriq_gym.qplatform.device.normalized_metadata", lambda *_: {})
 
-    args = SimpleNamespace(config="wit.json", provider="aws", device=device.id)
-    dispatch_job(args, jm)
+    dispatch_job("wit.json", "aws", device.id, jm)
 
     out = capsys.readouterr().out
     assert "failed to dispatch" in out
@@ -279,43 +276,36 @@ def test_dispatch_job_records_failed_attempt(monkeypatch, tmp_path, capsys):
 
 def test_resolve_upload_outcome_failed_job_defaults_to_error():
     job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
-    args = SimpleNamespace(outcome=None, reason=None)
-    assert _resolve_upload_outcome(args, job, has_result=False) == (RecordOutcome.ERROR, None)
+    assert _resolve_upload_outcome(None, None, job, has_result=False) == (RecordOutcome.ERROR, None)
 
 
 def test_resolve_upload_outcome_pending_job_refused(capsys):
-    args = SimpleNamespace(outcome=None, reason=None)
-    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert _resolve_upload_outcome(None, None, _job(), has_result=False) is None
     assert "not yet completed" in capsys.readouterr().out
 
 
 def test_resolve_upload_outcome_completed_job_is_plain_upload():
-    args = SimpleNamespace(outcome=None, reason=None)
-    assert _resolve_upload_outcome(args, _job(), has_result=True) == (None, None)
+    assert _resolve_upload_outcome(None, None, _job(), has_result=True) == (None, None)
 
 
 def test_resolve_upload_outcome_refuses_to_reclassify_completed_job(capsys):
-    args = SimpleNamespace(outcome="unsupported", reason="r")
-    assert _resolve_upload_outcome(args, _job(), has_result=True) is None
+    assert _resolve_upload_outcome("unsupported", "r", _job(), has_result=True) is None
     assert "refusing" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("outcome", ["unsupported", "not_applicable"])
 def test_resolve_upload_outcome_human_outcomes_require_reason(outcome, capsys):
     job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
-    args = SimpleNamespace(outcome=outcome, reason=None)
-    assert _resolve_upload_outcome(args, job, has_result=False) is None
+    assert _resolve_upload_outcome(outcome, None, job, has_result=False) is None
     assert "requires --reason" in capsys.readouterr().out
-    args.reason = "  because  "
-    assert _resolve_upload_outcome(args, job, has_result=False) == (
+    assert _resolve_upload_outcome(outcome, "  because  ", job, has_result=False) == (
         RecordOutcome(outcome),
         "because",
     )
 
 
 def test_resolve_upload_outcome_rejects_unknown_value(capsys):
-    args = SimpleNamespace(outcome="exploded", reason=None)
-    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert _resolve_upload_outcome("exploded", None, _job(), has_result=False) is None
     assert "--outcome must be one of" in capsys.readouterr().out
 
 
@@ -341,16 +331,13 @@ def test_upload_job_failed_job_writes_error_outcome_record(monkeypatch, tmp_path
 
     monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", FakeExporter)
 
-    args = SimpleNamespace(
-        job_id="job-1",
-        repo="owner/repo",
-        dry_run=True,
-        no_cache=False,
-        include_raw=False,
+    upload_job(
+        "job-1",
+        jm,
         outcome="unsupported",
         reason="Device rejects barriers",
+        options=UploadOptions(repo="owner/repo", dry_run=True),
     )
-    upload_job(args, jm)
 
     out = capsys.readouterr().out
     assert "Uploading as 'unsupported' outcome record" in out
@@ -391,10 +378,7 @@ def test_upload_suite_includes_failed_jobs_as_error_outcomes(monkeypatch, tmp_pa
 
     monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", FakeExporter)
 
-    args = SimpleNamespace(
-        suite_id="suite-1", repo="owner/repo", dry_run=True, no_cache=False, include_raw=False
-    )
-    upload_suite(args, jm)
+    upload_suite("suite-1", jm, options=UploadOptions(repo="owner/repo", dry_run=True))
 
     assert "will be uploaded as an 'error' outcome" in capsys.readouterr().out
     records = captured["payload"]
@@ -412,8 +396,7 @@ def test_upload_suite_includes_failed_jobs_as_error_outcomes(monkeypatch, tmp_pa
 def test_resolve_upload_outcome_accepts_enum_and_case_insensitive_strings():
     job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
     for raw in (RecordOutcome.UNSUPPORTED, "UNSUPPORTED", " unsupported "):
-        args = SimpleNamespace(outcome=raw, reason="r")
-        assert _resolve_upload_outcome(args, job, has_result=False) == (
+        assert _resolve_upload_outcome(raw, "r", job, has_result=False) == (
             RecordOutcome.UNSUPPORTED,
             "r",
         )
@@ -421,20 +404,19 @@ def test_resolve_upload_outcome_accepts_enum_and_case_insensitive_strings():
 
 def test_resolve_upload_outcome_blank_reason_counts_as_missing(capsys):
     job = _job(error={"source": "poll", "message": "m", "timestamp": "t"})
-    args = SimpleNamespace(outcome="unsupported", reason="   ")
-    assert _resolve_upload_outcome(args, job, has_result=False) is None
+    assert _resolve_upload_outcome("unsupported", "   ", job, has_result=False) is None
     assert "requires --reason" in capsys.readouterr().out
 
 
 def test_resolve_upload_outcome_refuses_hand_asserted_error_without_failure(capsys):
-    args = SimpleNamespace(outcome="error", reason=None)
-    assert _resolve_upload_outcome(args, _job(), has_result=False) is None
+    assert _resolve_upload_outcome("error", None, _job(), has_result=False) is None
     assert "no recorded failure" in capsys.readouterr().out
 
 
 def test_resolve_upload_outcome_human_outcome_on_pending_job_warns(capsys):
-    args = SimpleNamespace(outcome="not_applicable", reason="wrong device class")
-    assert _resolve_upload_outcome(args, _job(), has_result=False) == (
+    assert _resolve_upload_outcome(
+        "not_applicable", "wrong device class", _job(), has_result=False
+    ) == (
         RecordOutcome.NOT_APPLICABLE,
         "wrong device class",
     )
@@ -448,7 +430,7 @@ def test_fetch_result_trusts_recorded_poll_failure_without_provider(monkeypatch,
     load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
     _patch_fetch(monkeypatch, load_job)
 
-    assert fetch_result(job, SimpleNamespace(no_cache=False, include_raw=False), jm) is None
+    assert fetch_result(job, jm, no_cache=False) is None
     assert "Job failed at poll" in capsys.readouterr().out
     load_job.assert_not_called()
 
@@ -461,7 +443,7 @@ def test_fetch_result_no_cache_repolls_poll_failed_job(monkeypatch, tmp_path):
     _patch_fetch(monkeypatch, load_job)
     monkeypatch.setattr("metriq_gym.run.failed_jobs_summary", lambda qjobs: "pj-1: FAILED - again")
 
-    assert fetch_result(job, SimpleNamespace(no_cache=True, include_raw=False), jm) is None
+    assert fetch_result(job, jm, no_cache=True) is None
     load_job.assert_called_once()
     assert job.error["message"] == "pj-1: FAILED - again"
 
@@ -476,23 +458,14 @@ def test_fetch_result_no_cache_never_repolls_dispatch_failure(monkeypatch, tmp_p
     load_job = MagicMock(side_effect=AssertionError("must not poll provider"))
     _patch_fetch(monkeypatch, load_job)
 
-    assert fetch_result(job, SimpleNamespace(no_cache=True, include_raw=False), jm) is None
+    assert fetch_result(job, jm, no_cache=True) is None
     load_job.assert_not_called()
 
 
-def _upload_args(**overrides):
-    args = SimpleNamespace(
-        job_id="job-1",
-        repo="owner/repo",
-        dry_run=True,
-        no_cache=False,
-        include_raw=False,
-        outcome=None,
-        reason=None,
-    )
-    for k, v in overrides.items():
-        setattr(args, k, v)
-    return args
+def _upload(jm, *, job_id="job-1", outcome=None, reason=None, **option_overrides):
+    """Call upload_job with the defaults these tests share."""
+    options = UploadOptions(repo="owner/repo", dry_run=True, **option_overrides)
+    upload_job(job_id, jm, outcome=outcome, reason=reason, options=options)
 
 
 def _install_fake_exporter(monkeypatch):
@@ -518,7 +491,7 @@ def test_upload_job_provider_error_without_outcome_fails_cleanly(monkeypatch, tm
     )
     captured = _install_fake_exporter(monkeypatch)
 
-    upload_job(_upload_args(), jm)  # must not raise
+    _upload(jm)  # must not raise
 
     out = capsys.readouterr().out
     assert "Could not fetch status/results" in out
@@ -537,7 +510,7 @@ def test_upload_job_provider_error_with_explicit_outcome_still_uploads(
     )
     captured = _install_fake_exporter(monkeypatch)
 
-    upload_job(_upload_args(outcome=RecordOutcome.UNSUPPORTED, reason="compiler limit"), jm)
+    _upload(jm, outcome=RecordOutcome.UNSUPPORTED, reason="compiler limit")
 
     out = capsys.readouterr().out
     assert "Continuing with the requested --outcome" in out
@@ -554,10 +527,10 @@ def test_upload_job_custom_title_gets_outcome_suffix(monkeypatch, tmp_path):
     monkeypatch.setattr("metriq_gym.run.setup_benchmark_result_class", lambda *_: DummyResult)
     captured = _install_fake_exporter(monkeypatch)
 
-    upload_job(_upload_args(pr_title="My title"), jm)
+    _upload(jm, pr_title="My title")
     assert captured["pr_title"] == "My title (error)"
 
-    upload_job(_upload_args(pr_title="My title (error)"), jm)
+    _upload(jm, pr_title="My title (error)")
     assert captured["pr_title"] == "My title (error)"
 
 
@@ -577,7 +550,7 @@ def test_upload_job_exporter_failure_is_reported_not_raised(monkeypatch, tmp_pat
 
     monkeypatch.setattr("metriq_gym.exporters.github_pr_exporter.GitHubPRExporter", BrokenExporter)
 
-    upload_job(_upload_args(), jm)
+    _upload(jm)
     out = capsys.readouterr().out
     assert "✗ Upload failed: GitHub token not provided" in out
 
@@ -590,12 +563,7 @@ def test_upload_suite_provider_error_fails_cleanly(monkeypatch, tmp_path, capsys
     )
     captured = _install_fake_exporter(monkeypatch)
 
-    upload_suite(
-        SimpleNamespace(
-            suite_id="suite-1", repo="owner/repo", dry_run=True, no_cache=False, include_raw=False
-        ),
-        jm,
-    )
+    upload_suite("suite-1", jm, options=UploadOptions(repo="owner/repo", dry_run=True))
     assert "Could not fetch status/results" in capsys.readouterr().out
     assert "payload" not in captured
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -259,10 +259,8 @@ def test_setup_device_empty_device(mock_provider, patch_load_provider, caplog):
 
 
 @patch("os.path.exists")
-def test_dispatch_missing_config_file(mock_exists, mock_args, mock_job_manager, capsys):
+def test_dispatch_missing_config_file(mock_exists, mock_job_manager, capsys):
     """Test behavior when configuration file is missing."""
-    # Setup mocks
-    mock_args.benchmark_config = "missing.json"
     mock_exists.return_value = False  # Simulate missing files
 
     # Mock setup_device to avoid provider validation error
@@ -271,7 +269,7 @@ def test_dispatch_missing_config_file(mock_exists, mock_args, mock_job_manager, 
         mock_setup_device.return_value = mock_device
 
         # Execute function
-        dispatch_job(mock_args, mock_job_manager)
+        dispatch_job("missing.json", "ibm", "ibm_device", mock_job_manager)
 
         # Verify output shows file not found errors
         captured = capsys.readouterr()
@@ -303,11 +301,6 @@ def test_dispatch_suite_skips_benchmark_exceeding_device_capacity(
         id="arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1",
         num_qubits=36,
     )
-    args = SimpleNamespace(
-        provider="aws",
-        device=device.id,
-        suite_config=str(suite_file),
-    )
     registry = MagicMock()
     registry.get_available_benchmarks.return_value = ["Linear Ramp QAOA"]
     setup_benchmark_mock = MagicMock(
@@ -318,7 +311,7 @@ def test_dispatch_suite_skips_benchmark_exceeding_device_capacity(
     monkeypatch.setattr("metriq_gym.run._lazy_registry", lambda: registry)
     monkeypatch.setattr("metriq_gym.run.setup_benchmark", setup_benchmark_mock)
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "aws", device.id, mock_job_manager)
 
     output = capsys.readouterr().out
     assert "Requested 50 qubits" in output
@@ -394,13 +387,8 @@ def test_dispatch_guarded_suite_requires_selection_before_device_setup(
     suite_file = _write_component_suite(tmp_path)
     setup_device_mock = MagicMock()
     monkeypatch.setattr("metriq_gym.run.setup_device", setup_device_mock)
-    args = SimpleNamespace(
-        provider="ibm",
-        device="ibm_device",
-        suite_config=str(suite_file),
-    )
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "ibm", "ibm_device", mock_job_manager)
 
     output = capsys.readouterr().out
     assert "WARNING: This test suite is expensive." in output
@@ -415,15 +403,12 @@ def test_dispatch_suite_selects_all_entries_in_component(
 ):
     suite_file = _write_component_suite(tmp_path)
     _, setup_benchmark_mock = _patch_successful_suite_dispatch(monkeypatch)
-    args = SimpleNamespace(
-        provider="ibm",
-        device="ibm_device",
-        suite_config=str(suite_file),
+    extra = dict(
         components=["qft"],
         all_components=False,
     )
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "ibm", "ibm_device", mock_job_manager, **extra)
 
     output = capsys.readouterr().out
     assert "qft_small" in output
@@ -439,15 +424,12 @@ def test_dispatch_suite_all_explicitly_opts_into_guarded_suite(
 ):
     suite_file = _write_component_suite(tmp_path)
     _, setup_benchmark_mock = _patch_successful_suite_dispatch(monkeypatch)
-    args = SimpleNamespace(
-        provider="ibm",
-        device="ibm_device",
-        suite_config=str(suite_file),
+    extra = dict(
         components=None,
         all_components=True,
     )
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "ibm", "ibm_device", mock_job_manager, **extra)
 
     output = capsys.readouterr().out
     assert "WARNING: This test suite is expensive." in output
@@ -461,13 +443,8 @@ def test_dispatch_legacy_suite_still_runs_all_without_all_flag(
 ):
     suite_file = _write_component_suite(tmp_path, guarded=False)
     _, setup_benchmark_mock = _patch_successful_suite_dispatch(monkeypatch)
-    args = SimpleNamespace(
-        provider="ibm",
-        device="ibm_device",
-        suite_config=str(suite_file),
-    )
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "ibm", "ibm_device", mock_job_manager)
 
     output = capsys.readouterr().out
     assert "Successfully dispatched 3/3 benchmarks" in output
@@ -495,15 +472,12 @@ def test_dispatch_suite_rejects_invalid_selection_before_device_setup(
     suite_file = _write_component_suite(tmp_path)
     setup_device_mock = MagicMock()
     monkeypatch.setattr("metriq_gym.run.setup_device", setup_device_mock)
-    args = SimpleNamespace(
-        provider="ibm",
-        device="ibm_device",
-        suite_config=str(suite_file),
+    extra = dict(
         components=components,
         all_components=all_components,
     )
 
-    dispatch_suite(args, mock_job_manager)
+    dispatch_suite(str(suite_file), "ibm", "ibm_device", mock_job_manager, **extra)
 
     assert expected_error in capsys.readouterr().out
     setup_device_mock.assert_not_called()
@@ -565,13 +539,7 @@ def test_estimate_job_quantinuum_defaults(monkeypatch, capsys):
     monkeypatch.setattr("metriq_gym.run.aggregate_resource_estimates", fake_aggregate)
     monkeypatch.setattr("metriq_gym.run.print_resource_estimate", lambda *_: None)
 
-    args = SimpleNamespace(
-        config="foo.json",
-        provider="quantinuum",
-        device="H1-1",
-    )
-
-    estimate_job(args, MagicMock())
+    estimate_job("foo.json", "quantinuum", "H1-1", MagicMock())
 
     expected = quantinuum_hqc_formula(GateCounts(), 16, 6)
     assert abs(captured["hqc"] - expected) < 1e-6
@@ -630,13 +598,7 @@ def test_estimate_job_without_device_wit(monkeypatch, capsys):
 
     monkeypatch.setattr("metriq_gym.run.aggregate_resource_estimates", fake_aggregate)
 
-    args = SimpleNamespace(
-        config="foo.json",
-        provider="quantinuum",
-        device=None,
-    )
-
-    estimate_job(args, MagicMock())
+    estimate_job("foo.json", "quantinuum", None, MagicMock())
 
     output = capsys.readouterr().out
     assert "Resource estimate for WIT" in output
@@ -664,13 +626,7 @@ def test_estimate_job_requires_device(monkeypatch, capsys):
     )
     monkeypatch.setattr("metriq_gym.run.setup_benchmark", lambda *_, **__: mock_benchmark)
 
-    args = SimpleNamespace(
-        config="foo.json",
-        provider="aws",
-        device=None,
-    )
-
-    estimate_job(args, MagicMock())
+    estimate_job("foo.json", "aws", None, MagicMock())
 
     output = capsys.readouterr().out
     assert "✗ BSEQ" in output
@@ -728,9 +684,7 @@ def test_fetch_result_uses_cache_when_no_flag(monkeypatch):
     job = _make_cached_job(EXPECTED_CACHED_VALUE)
     jm = JobManager()
     jm.jobs.append(job)
-    args = MagicMock()
-    args.no_cache = False
-    args.include_raw = False
+    no_cache = False
 
     import metriq_gym.run as run_mod
 
@@ -744,7 +698,7 @@ def test_fetch_result_uses_cache_when_no_flag(monkeypatch):
     )
     monkeypatch.setattr(run_mod, "validate_and_create_model", lambda params: params)
 
-    fetch_output = fetch_result(job, args, jm)
+    fetch_output = fetch_result(job, jm, no_cache=no_cache)
     assert fetch_output.result.value == EXPECTED_CACHED_VALUE
     assert fetch_output.from_cache is True
 
@@ -755,9 +709,7 @@ def test_fetch_result_bypasses_cache_with_flag(monkeypatch):
     job = _make_cached_job(CACHED_VALUE)
     jm = JobManager()
     jm.jobs.append(job)
-    args = MagicMock()
-    args.no_cache = True
-    args.include_raw = False
+    no_cache = True
 
     import metriq_gym.run as run_mod
 
@@ -771,7 +723,7 @@ def test_fetch_result_bypasses_cache_with_flag(monkeypatch):
     )
     monkeypatch.setattr(run_mod, "validate_and_create_model", lambda params: params)
 
-    fetch_output = fetch_result(job, args, jm)
+    fetch_output = fetch_result(job, jm, no_cache=no_cache)
     assert fetch_output.result.value == EXPECTED_FRESH_VALUE, (
         "Should fetch fresh value when --no-cache specified"
     )
@@ -790,9 +742,7 @@ def test_fetch_result_includes_raw_counts_when_flag_set(monkeypatch):
     job.result_data = None
     jm = JobManager()
     jm.jobs.append(job)
-    args = MagicMock()
-    args.no_cache = False
-    args.include_raw = True
+    no_cache = False
 
     # Create a fake quantum job that returns real GateModelResultData
     class FakeQuantumJobWithRealData:
@@ -829,7 +779,7 @@ def test_fetch_result_includes_raw_counts_when_flag_set(monkeypatch):
     )
     monkeypatch.setattr(run_mod, "validate_and_create_model", lambda params: params)
 
-    fetch_output = fetch_result(job, args, jm)
+    fetch_output = fetch_result(job, jm, no_cache=no_cache)
     assert fetch_output.raw_results is not None
     assert len(fetch_output.raw_results) == 1
     # Check that the first result is a GateModelResultData and has the expected measurement_counts


### PR DESCRIPTION
Part of: #564

Step 1 of the two-step plan on that issue. The CLI moved to typer, but `run.py` never followed: its entry points kept taking `args: argparse.Namespace`, and `cli.py` synthesized a throwaway namespace at eleven call sites purely to satisfy them.

```python
args = argparse.Namespace()
args.job_id = job_id
args.no_cache = no_cache
...
_poll_job(args, job_manager)
```

That shim is why the module resists being split: every function's real inputs were hidden behind an untyped attribute bag, so you could not move one without tracing which attributes it happened to read. The seventeen entry points now take the arguments they use, and `argparse` is gone from both files.

This is deliberately behaviour-only-preserving. The file split is step 2 and is much easier to review once the signatures say what they need.

## Three things that fell out

`Benchmark.__init__` took a `Namespace` and stored it as `self.args`, which no benchmark ever read. `setup_benchmark` existed only to forward it, and `estimate_job` built an empty namespace purely to satisfy the call. Removing it took the placeholder with it, which ruff then confirmed as `F841: local variable 'args' is assigned to but never used`.

The nine upload flags are identical between job and suite upload, so they move into an `UploadOptions` dataclass rather than being repeated as ten keyword parameters on two functions.

`hasattr(args, "json")` was standing in for "was the flag passed", since `cli.py` only set the attribute when `--json` was given. That is now an explicit `json_path is not None`.

## One latent annotation bug surfaced

With real types in place, mypy could finally see these values. It flagged that `setup_device` is annotated `(provider_name: str, device_name: str)` while its body explicitly handles falsy input:

```python
if not provider_name:
    ...
    raise QBraidSetupError("Provider not found")
```

The CLI options are `Optional`, so `None` really does reach it. The annotation is widened to match the behaviour. `dispatch_job` was also shadowing its `device` parameter with the resolved device object, which the rename made visible; the parameter is now `device_name`.

## Verification

462 tests pass, ruff and mypy clean. Beyond the suite I exercised the real CLI end to end against the local Aer provider: `dispatch`, `poll` (correct WIT expectation value of 0.9967), `view`, and `delete`.

Note for whoever merges: #818 also touches the three `fetch_result` tests in `tests/unit/test_run.py`, so expect a small conflict there depending on merge order.
