### PR TITLE
Fix UTC timestamps for job and suite uploads

### DIFF
--- a/docs/content/getting-started/metriq-platform.md
+++ b/docs/content/getting-started/metriq-platform.md
@@ -49,7 +49,7 @@ usually contains one record; suite uploads contain several.
 [
   {
     "app_version": "0.6.0",
-    "timestamp": "2026-01-16T15:42:18.173736",
+    "timestamp": "2026-01-16T15:42:18.173736+00:00",
     "suite_id": null,
     "job_type": "BSEQ",
     "results": {
@@ -86,7 +86,7 @@ report uncertainty on a metric use that same object shape for the metric itself.
 | Field | Description |
 |-------|-------------|
 | `app_version` | `metriq-gym` version that generated the record |
-| `timestamp` | ISO 8601 dispatch timestamp recorded by `metriq-gym` |
+| `timestamp` | ISO 8601 dispatch timestamp in UTC, with an explicit `+00:00` offset |
 | `suite_id` | Nullable suite identifier; `null` for single-job uploads |
 | `job_type` | Benchmark name, such as `BSEQ` or `WIT` |
 | `results` | Benchmark outputs. Metrics may be plain numbers or `{value, uncertainty}` objects; `results.score` is the summary score when the benchmark defines one |
@@ -94,6 +94,11 @@ report uncertainty on a metric use that same object shape for the metric itself.
 | `platform.device` | Device or backend identifier used for the run |
 | `platform.device_metadata` | Optional normalized metadata such as `num_qubits`, `simulator`, and backend `version` |
 | `params` | Validated benchmark configuration used to run the job |
+
+Upload filenames also use UTC. Older jobs saved without a timezone are interpreted
+in the machine's local timezone, using the offset at the dispatch date. Export those
+jobs with the same timezone used at dispatch; if it has changed, set `TZ` to the
+original timezone (for example, `TZ=Europe/Madrid mgym job upload <job-id>`).
 
 ## Contributing Quality Data
 

--- a/metriq_gym/dashboard/server.py
+++ b/metriq_gym/dashboard/server.py
@@ -168,6 +168,18 @@ def job_state(raw: dict, state: dict) -> tuple[str, int | None]:
     return "unknown", None
 
 
+def _dispatch_time_sort_key(job: dict) -> datetime:
+    """Sort by UTC time, treating legacy naive timestamps as local time."""
+    timestamp = job.get("dispatch_time")
+    if isinstance(timestamp, str):
+        try:
+            return datetime.fromisoformat(timestamp).astimezone(timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            pass
+    # Keep partial or malformed records visible, after all dated jobs.
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
 def wire_jobs() -> list[dict]:
     with _state_lock:
         state = load_state()
@@ -206,7 +218,7 @@ def wire_jobs() -> list[dict]:
                 "uploaded_at": upload.get("uploaded_at"),
             }
         )
-    out.sort(key=lambda j: j["dispatch_time"] or "", reverse=True)
+    out.sort(key=_dispatch_time_sort_key, reverse=True)
     return out
 
 

--- a/metriq_gym/exporters/base_exporter.py
+++ b/metriq_gym/exporters/base_exporter.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import timezone
 from typing import Any
 
 from metriq_gym.benchmarks.benchmark import BenchmarkResult
@@ -71,10 +72,13 @@ class BaseExporter(ABC):
             results_block = self.result.model_dump()
             if results_block.get("score") is None:
                 results_block.pop("score", None)
+        # Legacy jobs contain naive local times. astimezone uses the system's
+        # local timezone at the dispatch date when no offset was recorded.
+        dispatch_time = self.metriq_gym_job.dispatch_time.astimezone(timezone.utc)
         # Do not emit a separate uncertainties block; structured fields carry their own
         record = {
             "app_version": self.metriq_gym_job.app_version,
-            "timestamp": self.metriq_gym_job.dispatch_time.isoformat(),
+            "timestamp": dispatch_time.isoformat(),
             "suite_id": self.metriq_gym_job.suite_id,
             "job_type": self.metriq_gym_job.job_type.value,
             "results": results_block,

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -2,7 +2,7 @@
 
 import argparse
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import sys
 import logging
@@ -308,7 +308,7 @@ def _new_job(
             "device": args.device,
             "device_metadata": normalized_metadata(device),
         },
-        dispatch_time=datetime.now(),
+        dispatch_time=datetime.now(timezone.utc),
     )
 
 

--- a/metriq_gym/upload_paths.py
+++ b/metriq_gym/upload_paths.py
@@ -3,7 +3,7 @@
 import re
 import json
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from metriq_gym.platform import canonical_device_name, canonical_provider_name
@@ -50,7 +50,8 @@ def _hash_label(payload: Any) -> str:
 
 
 def job_filename(job: "MetriqGymJob", *, payload: Any = None) -> str:
-    dispatch_time = job.dispatch_time or datetime.now()
+    """Use UTC for filenames, interpreting legacy naive dispatch times as local."""
+    dispatch_time = (job.dispatch_time or datetime.now(timezone.utc)).astimezone(timezone.utc)
 
     job_label = path_component(str(job.job_type.value))
     hash_label = _hash_label(payload) if payload is not None else None
@@ -62,9 +63,10 @@ def job_filename(job: "MetriqGymJob", *, payload: Any = None) -> str:
 def suite_filename(
     suite_name: str | None, dispatch_time: datetime | None = None, *, payload: Any = None
 ) -> str:
-    """Construct a filename for suite uploads using suite name and dispatch time."""
+    """Use UTC for suite filenames, interpreting legacy naive dispatch times as local."""
     suite_label = path_component(suite_name or "suite")
     hash_label = _hash_label(payload) if payload is not None else None
-    ts = (dispatch_time or datetime.now()).strftime("%Y-%m-%d_%H-%M-%S")
+    dispatch_time = (dispatch_time or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    ts = dispatch_time.strftime("%Y-%m-%d_%H-%M-%S")
     suffix = f"_{hash_label}" if hash_label else ""
     return f"{ts}_{suite_label}{suffix}.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,24 @@
 from datetime import datetime
+import time
 
 import pytest
 
 from metriq_gym.constants import JobType
 from metriq_gym.job_manager import MetriqGymJob
+
+
+@pytest.fixture
+def local_timezone(monkeypatch, request):
+    """Run with a non-UTC system timezone, restoring it even if the test fails."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("Changing the system timezone requires time.tzset")
+    try:
+        with monkeypatch.context() as env:
+            env.setenv("TZ", getattr(request, "param", "Europe/Madrid"))
+            time.tzset()
+            yield
+    finally:
+        time.tzset()
 
 
 @pytest.fixture

--- a/tests/e2e/test_dispatch_poll_suite.py
+++ b/tests/e2e/test_dispatch_poll_suite.py
@@ -1,8 +1,11 @@
 import json
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+
+from metriq_gym.job_manager import JobManager
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +15,8 @@ def store_env(monkeypatch, tmp_path):
 
 
 @pytest.mark.e2e
-def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
+@pytest.mark.parametrize("local_timezone", ["Europe/Madrid", "America/New_York"], indirect=True)
+def test_dispatch_and_poll_suite_on_local_simulator(tmp_path, local_timezone):
     """
     End-to-end test of the CLI workflow for a suite with two jobs on the local simulator
         1. dispatch   -> returns a Metriq-Gym suite_id and two job_ids
@@ -24,6 +28,7 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
     # 1. Dispatch a suite with two benchmarks on the local Aer simulator
     # ------------------------------------------------------------------
     example_suite_cfg = Path(__file__).parent.resolve() / "test_suite.json"
+    before_dispatch = datetime.now(timezone.utc)
 
     dispatch_cmd = subprocess.run(
         [
@@ -40,6 +45,7 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
         text=True,
         check=True,
     )
+    after_dispatch = datetime.now(timezone.utc)
     assert "Dispatch complete for suite" in dispatch_cmd.stdout
 
     # Extract suite_id from output (assumes suite_id is printed in stdout)
@@ -49,6 +55,12 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
             suite_id = line.split()[-1].strip(".")
             break
     assert suite_id, "Suite ID not found in dispatch output"
+
+    jobs = JobManager().get_jobs_by_suite_id(suite_id)
+    assert len(jobs) == 2
+    for job in jobs:
+        assert job.dispatch_time.tzinfo is timezone.utc
+        assert before_dispatch <= job.dispatch_time <= after_dispatch
 
     # ------------------------------------------------------------------
     # 2. Poll the suite
@@ -84,7 +96,32 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path):
 
     with open(path_part) as f:
         arr = json.load(f)
-        assert isinstance(arr, list) and len(arr) >= 2
+    assert isinstance(arr, list) and len(arr) == 2
+    assert [record["timestamp"] for record in arr] == [
+        job.dispatch_time.isoformat() for job in jobs
+    ]
+    assert all(record["timestamp"].endswith("+00:00") for record in arr)
+    expected_prefix = jobs[0].dispatch_time.strftime("%Y-%m-%d_%H-%M-%S")
+    assert Path(path_part).name.startswith(f"{expected_prefix}_local_sim_suite_")
+
+    # Re-export the same suite using the naive local timestamps stored by older
+    # versions. Every record and the filename must still identify the same UTC time.
+    job_manager = JobManager()
+    for job in job_manager.get_jobs_by_suite_id(suite_id):
+        job.dispatch_time = job.dispatch_time.astimezone().replace(tzinfo=None)
+        job_manager.update_job(job)
+    legacy_upload = subprocess.run(
+        ["mgym", "suite", "upload", suite_id, "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    legacy_line = next(
+        line for line in legacy_upload.stdout.splitlines() if line.startswith("DRY-RUN:")
+    )
+    legacy_path = Path(legacy_line.split(" at ", 1)[1].split(";", 1)[0].strip())
+    assert json.loads(legacy_path.read_text()) == arr
+    assert legacy_path.name == Path(path_part).name
 
     # ------------------------------------------------------
     # 4. Delete the suite to clean up

--- a/tests/unit/exporters/test_json_exporter.py
+++ b/tests/unit/exporters/test_json_exporter.py
@@ -1,8 +1,12 @@
 import json
+from datetime import datetime
+
+import pytest
 
 from metriq_gym.benchmarks.benchmark import BenchmarkScore
 from metriq_gym.benchmarks.wit import WITResult
 from metriq_gym.exporters.json_exporter import JsonExporter
+from metriq_gym.job_manager import MetriqGymJob
 
 
 def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path):
@@ -16,3 +20,32 @@ def test_json_exporter_serializes_none_uncertainty_to_null(metriq_job, tmp_path)
 
     assert data["results"]["expectation_value"]["value"] == 0.42
     assert data["results"]["expectation_value"]["uncertainty"] is None
+
+
+@pytest.mark.parametrize("completed", [True, False])
+@pytest.mark.parametrize(
+    "dispatch_time, expected",
+    [
+        ("2026-09-09T14:34:31.123456+00:00", "2026-09-09T14:34:31.123456+00:00"),
+        ("2026-09-09T16:34:31.123456+02:00", "2026-09-09T14:34:31.123456+00:00"),
+        ("2026-09-09T23:34:31-05:00", "2026-09-10T04:34:31+00:00"),
+        ("2026-09-09T00:34:31+05:30", "2026-09-08T19:04:31+00:00"),
+        # Legacy jobs stored local wall time without an offset. Use Madrid's
+        # offset at dispatch, including winter dates exported during summer.
+        ("2026-09-09T16:34:31", "2026-09-09T14:34:31+00:00"),
+        ("2026-01-09T16:34:31", "2026-01-09T15:34:31+00:00"),
+    ],
+)
+def test_json_exporter_uses_utc_timestamp(
+    metriq_job, tmp_path, local_timezone, completed, dispatch_time, expected
+):
+    metriq_job.dispatch_time = datetime.fromisoformat(dispatch_time)
+    job = MetriqGymJob.deserialize(metriq_job.serialize())
+    result = WITResult(expectation_value=BenchmarkScore(value=0.42)) if completed else None
+    outfile = tmp_path / "result.json"
+
+    JsonExporter(job, result).export(str(outfile))
+
+    data = json.loads(outfile.read_text())
+    assert data["timestamp"] == expected
+    assert job.dispatch_time == metriq_job.dispatch_time

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from metriq_gym.dashboard.server import db_path, wire_jobs
+
+
+@pytest.fixture
+def dashboard_db(monkeypatch, tmp_path):
+    monkeypatch.setenv("MGYM_LOCAL_DB_DIR", str(tmp_path))
+    return db_path()
+
+
+@pytest.mark.parametrize(
+    "local_timezone, legacy_timestamp, utc_timestamp",
+    [
+        ("Europe/Madrid", "2026-09-09T16:00:00", "2026-09-09T14:01:00+00:00"),
+        ("Europe/Madrid", "2026-01-09T16:00:00", "2026-01-09T15:01:00+00:00"),
+        ("America/New_York", "2026-09-09T10:00:00", "2026-09-09T14:01:00+00:00"),
+        ("America/New_York", "2026-01-09T09:00:00", "2026-01-09T14:01:00+00:00"),
+    ],
+    indirect=["local_timezone"],
+)
+def test_wire_jobs_sorts_mixed_dispatch_times_chronologically(
+    dashboard_db, local_timezone, legacy_timestamp, utc_timestamp
+):
+    month = utc_timestamp[5:7]
+    records = [
+        {"id": "legacy", "dispatch_time": legacy_timestamp},
+        {"id": "new-utc", "dispatch_time": utc_timestamp},
+        # These offsets cross a date boundary; raw string order would put the
+        # older record ahead of the newer one.
+        {"id": "old-offset", "dispatch_time": f"2026-{month}-10T00:00:00+14:00"},
+        {"id": "new-offset", "dispatch_time": f"2026-{month}-09T23:00:00-12:00"},
+    ]
+    dashboard_db.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+    jobs = wire_jobs()
+
+    assert [job["id"] for job in jobs] == ["new-offset", "new-utc", "legacy", "old-offset"]
+    # Sorting must not rewrite the stored timestamps or the API values.
+    original_times = {record["id"]: record["dispatch_time"] for record in records}
+    assert {job["id"]: job["dispatch_time"] for job in jobs} == original_times
+    assert [json.loads(line) for line in dashboard_db.read_text().splitlines()] == records
+
+
+def test_wire_jobs_keeps_invalid_dispatch_times_at_the_end(dashboard_db, local_timezone):
+    records = [
+        {"id": "invalid", "dispatch_time": "not-a-date"},
+        {"id": "missing"},
+        {"id": "null", "dispatch_time": None},
+        {"id": "numeric", "dispatch_time": 123},
+        {"id": "empty", "dispatch_time": ""},
+        {"id": "valid", "dispatch_time": "2026-09-09T14:01:00Z"},
+    ]
+    dashboard_db.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+    jobs = wire_jobs()
+
+    assert [job["id"] for job in jobs] == [
+        "valid",
+        "invalid",
+        "missing",
+        "null",
+        "numeric",
+        "empty",
+    ]

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import os
 import pytest
@@ -22,6 +22,7 @@ from metriq_gym.run import (
     estimate_job,
     _export_raw_debug_data,
     replay_from_debug_file,
+    _new_job,
 )
 from metriq_gym.job_manager import MetriqGymJob, JobManager
 from metriq_gym.constants import JobType
@@ -37,6 +38,22 @@ from metriq_gym.resource_estimation import (
 class FakeDevice:
     def __init__(self, id):
         self.id = id
+
+
+@pytest.mark.parametrize("local_timezone", ["Europe/Madrid", "America/New_York"], indirect=True)
+def test_new_job_persists_utc_dispatch_time(local_timezone):
+    args = SimpleNamespace(provider="local", device="aer_simulator")
+    params = SimpleNamespace(model_dump=lambda **_: {})
+    before = datetime.now(timezone.utc)
+
+    job = _new_job(args, FakeDevice(args.device), JobType.WIT, params, data={})
+
+    after = datetime.now(timezone.utc)
+    assert job.dispatch_time.tzinfo is timezone.utc
+    assert before <= job.dispatch_time <= after
+    reloaded = MetriqGymJob.deserialize(job.serialize())
+    assert reloaded.dispatch_time == job.dispatch_time
+    assert reloaded.dispatch_time.tzinfo is timezone.utc
 
 
 def test_main_loads_dotenv_from_working_directory(tmp_path, monkeypatch):

--- a/tests/unit/test_upload_paths.py
+++ b/tests/unit/test_upload_paths.py
@@ -1,5 +1,7 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
+
+import pytest
 
 from metriq_gym.constants import JobType
 from metriq_gym.job_manager import MetriqGymJob
@@ -54,7 +56,7 @@ def test_default_upload_dir_accepts_braket_alias_directly():
 
 
 def test_job_filename_structure():
-    when = datetime(2024, 1, 2, 3, 4, 5)
+    when = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 
     job = MetriqGymJob(
         id="job-1",
@@ -75,10 +77,39 @@ def test_job_filename_structure():
 
 
 def test_suite_filename_structure():
-    when = datetime(2024, 6, 7, 8, 9, 10)
+    when = datetime(2024, 6, 7, 8, 9, 10, tzinfo=timezone.utc)
     payload = [{"results": {"score": {"value": 1, "uncertainty": None}}}]
     name = suite_filename("My Suite", when, payload=payload)
     assert re.match(
         r"2024-06-07_08-09-10_my_suite_[0-9a-f]{8}\.json",
         name,
     )
+
+
+@pytest.mark.parametrize(
+    "dispatch_time, expected_prefix",
+    [
+        ("2026-09-09T14:34:31+00:00", "2026-09-09_14-34-31"),
+        ("2026-09-09T16:34:31+02:00", "2026-09-09_14-34-31"),
+        ("2026-09-09T23:34:31-05:00", "2026-09-10_04-34-31"),
+        ("2026-09-09T16:34:31", "2026-09-09_14-34-31"),
+        ("2026-01-09T16:34:31", "2026-01-09_15-34-31"),
+    ],
+)
+def test_upload_filenames_use_utc(metriq_job, local_timezone, dispatch_time, expected_prefix):
+    metriq_job.dispatch_time = datetime.fromisoformat(dispatch_time)
+
+    assert job_filename(metriq_job) == f"{expected_prefix}_wit.json"
+    assert (
+        suite_filename("My Suite", metriq_job.dispatch_time) == f"{expected_prefix}_my_suite.json"
+    )
+
+
+def test_suite_filename_defaults_to_utc(local_timezone):
+    before = datetime.now(timezone.utc).replace(microsecond=0)
+
+    name = suite_filename("My Suite")
+
+    after = datetime.now(timezone.utc)
+    timestamp = datetime.strptime(name[:19], "%Y-%m-%d_%H-%M-%S").replace(tzinfo=timezone.utc)
+    assert before <= timestamp <= after


### PR DESCRIPTION
# Description

Jobs dispatched outside UTC stored local timestamps without an offset. metriq-data interprets those values as UTC, so uploads could appear future-dated. Record new dispatch times in UTC, normalize exported timestamps to an explicit `+00:00` offset, and use UTC in job and suite filenames.

The dashboard also sorts jobs by their UTC dispatch times, so newer UTC records appear ahead of older legacy local records. Missing or invalid timestamps remain visible at the end of the list.

Legacy jobs without an offset are converted using the machine's local timezone at the dispatch date. Document that they must be exported using their original timezone. No new dependencies are required.

# Issue ticket number and link

Addresses [Copilot's timestamp finding in metriq-data PR #541](https://github.com/unitaryfoundation/metriq-data/pull/541#pullrequestreview-5155976764). Existing uploaded data is not rewritten by this change.

# Type of change

- [x] Bug fix
- [x] Documentation update

# How Has This Been Tested?

- **127 unit tests passed:** `.venv/bin/pytest -q tests/unit/test_dashboard.py tests/unit/exporters tests/unit/test_upload_paths.py tests/unit/test_run.py tests/unit/test_job_manager.py tests/unit/test_record_outcomes.py`. Coverage includes explicit offsets, legacy summer/winter timestamps, midnight crossings, completed/error records, and serialization. Dashboard tests exercise `wire_jobs()` against mixed records in Madrid and New York, including malformed dates.
- **2 suite end-to-end tests passed:** `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q tests/e2e/test_dispatch_poll_suite.py`. Dispatch and poll a two-job local simulator suite in both `Europe/Madrid` and `America/New_York`; verify persisted UTC dispatch times, every uploaded record, and the suite filename. Re-export with legacy naive local timestamps and assert identical JSON and filenames.
- Ruff lint, formatting of changed Python files, full-project mypy, and `git diff --check` passed. The dashboard commit also passed its per-file mypy hook.
- Two existing hook failures were reproduced on unchanged `main`: deptry flags unused `pyqpanda3`, and per-file mypy reports `run.py:531` (`union-attr`). Those hooks were skipped for the initial commit; full-project mypy passes. Only deptry was skipped for the dashboard commit.

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented the legacy timezone handling
- [x] I have made corresponding changes to the documentation
- [x] I have added regression tests
- [x] Relevant new and existing tests pass locally
- [x] No dependent downstream changes are required
