### PR TITLE
Add suite JSON polling and test distributions before publishing

### DIFF
--- a/.github/workflows/distribution-test.yml
+++ b/.github/workflows/distribution-test.yml
@@ -42,12 +42,15 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
-          python - <<'PY'
+          uv run --no-project --with packaging python - <<'PY'
           import email
           import os
           import pathlib
+          import re
           import tarfile
           import zipfile
+
+          from packaging.version import Version
 
           wheel, = pathlib.Path("dist").glob("*.whl")
           sdist, = pathlib.Path("dist").glob("*.tar.gz")
@@ -61,7 +64,9 @@ jobs:
           assert wheel_version and wheel_version == sdist_version, (wheel_version, sdist_version)
           tag = os.environ["RELEASE_TAG"]
           if tag:
-              assert tag == f"v{wheel_version}", (tag, wheel_version)
+              assert re.match(r"v[0-9]", tag), f"Invalid release tag: {tag}"
+              # Preserve accepted prerelease spellings, e.g. v0.5.1-alpha -> 0.5.1a0.
+              assert Version(tag[1:]) == Version(wheel_version), (tag, wheel_version)
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
               output.write(f"version={wheel_version}\n")
           PY

--- a/.github/workflows/distribution-test.yml
+++ b/.github/workflows/distribution-test.yml
@@ -1,0 +1,128 @@
+name: Distribution Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      release-tag:
+        description: Release tag whose version must match both distributions
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.22"
+      - name: Build wheel and source distribution
+        run: uv build
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
+      - name: Verify distribution versions
+        id: metadata
+        env:
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          python - <<'PY'
+          import email
+          import os
+          import pathlib
+          import tarfile
+          import zipfile
+
+          wheel, = pathlib.Path("dist").glob("*.whl")
+          sdist, = pathlib.Path("dist").glob("*.tar.gz")
+          with zipfile.ZipFile(wheel) as archive:
+              metadata, = (name for name in archive.namelist() if name.endswith(".dist-info/METADATA"))
+              wheel_version = email.message_from_bytes(archive.read(metadata))["Version"]
+          with tarfile.open(sdist) as archive:
+              metadata, = (member for member in archive.getmembers()
+                           if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO"))
+              sdist_version = email.message_from_bytes(archive.extractfile(metadata).read())["Version"]
+          assert wheel_version and wheel_version == sdist_version, (wheel_version, sdist_version)
+          tag = os.environ["RELEASE_TAG"]
+          if tag:
+              assert tag == f"v{wheel_version}", (tag, wheel_version)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"version={wheel_version}\n")
+          PY
+      - uses: actions/upload-artifact@v7
+        with:
+          name: python-distributions
+          path: dist/*
+          if-no-files-found: error
+
+  smoke:
+    name: Install ${{ matrix.distribution }} / ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.12", "3.13"]
+        distribution: [wheel]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.12"
+            distribution: sdist
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install OpenCL on Ubuntu
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y ocl-icd-opencl-dev
+      - name: Install OpenCL on macOS
+        if: runner.os == 'macOS'
+        run: brew install opencl-headers ocl-icd
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.22"
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-distributions
+          path: ${{ runner.temp }}/distributions
+      - name: Install distribution in a clean environment
+        working-directory: ${{ runner.temp }}
+        env:
+          DISTRIBUTION: ${{ matrix.distribution }}
+        run: |
+          uv venv smoke-venv --python "$(command -v python)"
+          if [ "$DISTRIBUTION" = wheel ]; then
+            artifacts=(distributions/*.whl)
+          else
+            artifacts=(distributions/*.tar.gz)
+          fi
+          test "${#artifacts[@]}" -eq 1
+          uv pip install --python smoke-venv/bin/python "${artifacts[0]}"
+          uv pip check --python smoke-venv/bin/python
+      - name: Exercise installed CLI and packaged resources
+        working-directory: ${{ runner.temp }}
+        env:
+          EXPECTED_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          cp "$GITHUB_WORKSPACE/scripts/smoke_distribution.py" smoke_distribution.py
+          unset PYTHONPATH
+          smoke-venv/bin/python -I smoke_distribution.py --expected-version "$EXPECTED_VERSION"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,37 +4,30 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-publish:
+  distributions:
     if: github.event.release.prerelease == false
-    name: Build and publish Python distributions to PyPI
+    uses: ./.github/workflows/distribution-test.yml
+    with:
+      release-tag: ${{ github.event.release.tag_name }}
+
+  publish:
+    needs: distributions
+    name: Publish tested distributions to PyPI
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write  # This is required for trusted publishing
 
     steps:
-      - name: Checkout repo + submodules
-        uses: actions/checkout@v7
+      - name: Download tested distributions
+        uses: actions/download-artifact@v8
         with:
-          submodules: recursive
-          fetch-depth: 0  # fetch full history and tags for versioning
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.8.22"
-
-      - name: Sync dependencies
-        run: uv sync --group dev --frozen
-
-      - name: Build package
-        run: uv build
+          name: python-distributions
+          path: dist
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -4,37 +4,30 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-publish:
+  distributions:
     if: github.event.release.prerelease == true
-    name: Build and publish Python distributions to TestPyPI
+    uses: ./.github/workflows/distribution-test.yml
+    with:
+      release-tag: ${{ github.event.release.tag_name }}
+
+  publish:
+    needs: distributions
+    name: Publish tested distributions to TestPyPI
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
       id-token: write  # This is required for trusted publishing
 
     steps:
-      - name: Checkout repo + submodules
-        uses: actions/checkout@v7
+      - name: Download tested distributions
+        uses: actions/download-artifact@v8
         with:
-          submodules: recursive
-          fetch-depth: 0  # fetch full history and tags for versioning
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.8.22"
-
-      - name: Sync dependencies
-        run: uv sync --group dev --frozen
-
-      - name: Build package
-        run: uv build
+          name: python-distributions
+          path: dist
 
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/content/cli/suite-commands.md
+++ b/docs/content/cli/suite-commands.md
@@ -91,6 +91,21 @@ mgym suite poll [suite_id] [OPTIONS]
 | `--json` | STR | Export results to JSON file | `None` |
 | `--no-cache` | BOOL | Ignore locally cached results and refetch | `False` |
 
+### Export results to JSON
+
+Write the suite's completed results to a file:
+
+```bash
+mgym suite poll <suite_id> --json suite-results.json
+```
+
+The file contains a JSON array in suite job order. Each record uses the same
+format as a completed job in `mgym suite upload`, including metadata, parameters,
+results, and a UTC timestamp. Without `--json`, results are displayed as a table.
+
+Failed jobs are reported and skipped. If any job is still pending, or no
+completed jobs remain, no file is written.
+
 ---
 
 ## view

--- a/docs/content/development/developer-guide.md
+++ b/docs/content/development/developer-guide.md
@@ -239,8 +239,46 @@ mgym job dispatch metriq_gym/schemas/examples/wit.example.json \
 Releases are managed by maintainers:
 
 1. Version is determined by `setuptools_scm` from git tags
-2. CI builds and publishes to PyPI
+2. CI builds and tests the wheel and source distribution before publishing to PyPI
 3. Documentation is deployed to GitHub Pages
+
+### Distribution checks
+
+The `Distribution Tests` workflow runs on pull requests and pushes to `main`.
+Both publishing workflows also call it: a failed build, metadata check, install,
+or simulator smoke test prevents publishing. Release builds must have the same
+version as their tag. PyPI and TestPyPI receive the exact artifacts that passed
+these checks.
+
+The wheel is installed in fresh environments on Linux and macOS with Python
+3.12 and 3.13. The source distribution is independently installed on Linux with
+Python 3.12. These installs resolve the dependencies declared in the package,
+without the development environment or `uv.lock`.
+
+The smoke script runs outside the checkout and checks the installed version,
+CLI entry point, JSON schemas, bundled suites, dashboard HTML, and benchmark
+modules from the submodules. It then dispatches and polls a small local Aer job
+and a two-job suite, checking their JSON results. No provider credentials are
+needed.
+
+To reproduce a wheel check locally on Linux or macOS:
+
+```bash
+uv build
+smoke_dir=$(mktemp -d)
+uv venv "$smoke_dir/venv" --python 3.12
+uv pip install --python "$smoke_dir/venv/bin/python" dist/*.whl
+uv pip check --python "$smoke_dir/venv/bin/python"
+cp scripts/smoke_distribution.py "$smoke_dir/"
+(
+    cd "$smoke_dir"
+    unset PYTHONPATH
+    ./venv/bin/python -I smoke_distribution.py
+)
+```
+
+Repeat with a fresh environment and `dist/*.tar.gz` to check the source
+distribution. OpenCL must be installed, as for the regular test workflow.
 
 ### Tag naming requirement
 

--- a/docs/content/development/developer-guide.md
+++ b/docs/content/development/developer-guide.md
@@ -247,8 +247,9 @@ Releases are managed by maintainers:
 The `Distribution Tests` workflow runs on pull requests and pushes to `main`.
 Both publishing workflows also call it: a failed build, metadata check, install,
 or simulator smoke test prevents publishing. Release builds must have the same
-version as their tag. PyPI and TestPyPI receive the exact artifacts that passed
-these checks.
+version as their tag after Python version normalization (for example,
+`v0.5.1-alpha` becomes `0.5.1a0`). PyPI and TestPyPI receive the exact artifacts
+that passed these checks.
 
 The wheel is installed in fresh environments on Linux and macOS with Python
 3.12 and 3.13. The source distribution is independently installed on Linux with

--- a/docs/generate_cli_docs.py
+++ b/docs/generate_cli_docs.py
@@ -67,6 +67,23 @@ component and scale-point reference.
 """
 
 
+SUITE_POLL_GUIDE = """### Export results to JSON
+
+Write the suite's completed results to a file:
+
+```bash
+mgym suite poll <suite_id> --json suite-results.json
+```
+
+The file contains a JSON array in suite job order. Each record uses the same
+format as a completed job in `mgym suite upload`, including metadata, parameters,
+results, and a UTC timestamp. Without `--json`, results are displayed as a table.
+
+Failed jobs are reported and skipped. If any job is still pending, or no
+completed jobs remain, no file is written.
+"""
+
+
 def extract_param_info(annotation, default):
     """Extract parameter info from Typer's Annotated type."""
     if get_origin(annotation) is Annotated:
@@ -282,7 +299,7 @@ def main():
         "suite",
         "Suite Commands",
         "Commands for dispatching, monitoring, and managing benchmark suites.",
-        command_extras={"dispatch": SUITE_DISPATCH_GUIDE},
+        command_extras={"dispatch": SUITE_DISPATCH_GUIDE, "poll": SUITE_POLL_GUIDE},
     )
     (content_dir / "suite-commands.md").write_text(suite_docs)
     print(f"Generated {content_dir / 'suite-commands.md'}")

--- a/metriq_gym/run.py
+++ b/metriq_gym/run.py
@@ -724,7 +724,11 @@ def export_suite_results(args, jobs: list[MetriqGymJob], results: list["Benchmar
         records.append(DictExporter(job, result).export() | {"params": job.params})
 
     if hasattr(args, "json"):
-        raise NotImplementedError("JSON export of suite results is not implemented yet.")
+        import json
+
+        with open(args.json, "w") as json_file:
+            json.dump(records, json_file, indent=4)
+        print(f"Results exported to {args.json}")
     else:
         print("\n--- Suite Metadata ---")
         print_selected(records[0], COMMON_SUITE_METADATA)

--- a/scripts/smoke_distribution.py
+++ b/scripts/smoke_distribution.py
@@ -1,0 +1,209 @@
+"""Check an installed distribution, without pytest or access to the source checkout.
+
+Copy this script to a temporary directory and run it with a fresh virtualenv's
+Python after installing a wheel or source archive. Do not use an editable install.
+"""
+
+import argparse
+from datetime import datetime, timedelta
+from importlib import import_module, metadata, resources
+import json
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import sysconfig
+import tempfile
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def check_installed_module(name: str) -> None:
+    module = import_module(name)
+    if module.__file__ is None:
+        raise RuntimeError(f"No installed file found for {name}")
+    path = Path(module.__file__).resolve()
+    require(
+        path.is_relative_to(Path(sys.prefix).resolve()),
+        f"{name} was imported from outside the test virtualenv: {path}",
+    )
+
+
+def check_package(expected_version: str | None) -> tuple[str, Path]:
+    require(sys.prefix != sys.base_prefix, "Run this check inside a fresh virtualenv")
+    check_installed_module("metriq_gym")
+
+    from metriq_gym import __version__
+
+    distribution = metadata.distribution("metriq-gym")
+    require(
+        distribution.version == __version__,
+        f"Metadata version {distribution.version} differs from runtime version {__version__}",
+    )
+    if expected_version is not None:
+        require(
+            __version__ == expected_version,
+            f"Expected version {expected_version}, installed {__version__}",
+        )
+    require(
+        any(
+            entry.group == "console_scripts"
+            and entry.name == "mgym"
+            and entry.value == "metriq_gym.run:main"
+            for entry in distribution.entry_points
+        ),
+        "The distribution does not register the mgym console script",
+    )
+    cli = Path(sysconfig.get_path("scripts")) / ("mgym.exe" if os.name == "nt" else "mgym")
+    require(cli.is_file(), f"The installed mgym console script is missing: {cli}")
+    require(
+        cli.resolve().is_relative_to(Path(sys.prefix).resolve()),
+        f"The mgym console script is outside the test virtualenv: {cli}",
+    )
+
+    from metriq_gym.benchmarks.qedc_benchmarks import QEDC_BENCHMARK_IMPORTS
+
+    # These submodule packages are imported dynamically by benchmark handlers.
+    for name in [
+        "_common.metrics",
+        *QEDC_BENCHMARK_IMPORTS.values(),
+        "qiskit_device_benchmarking.utilities.gate_map",
+    ]:
+        check_installed_module(name)
+
+    from metriq_gym.constants import SCHEMA_MAPPING
+    from metriq_gym.schema_validator import load_schema
+    from metriq_gym.suite_parser import parse_suite_file
+
+    package = resources.files("metriq_gym")
+    for benchmark, filename in SCHEMA_MAPPING.items():
+        schema = json.loads(package.joinpath("schemas", filename).read_text(encoding="utf-8"))
+        require(bool(schema.get("properties")), f"Empty schema for {benchmark}")
+        require(load_schema(benchmark) == schema, f"Cannot load packaged schema for {benchmark}")
+
+    suites = package.joinpath("suites")
+    suite_names = {entry.name for entry in suites.iterdir() if entry.name.endswith(".json")}
+    require(
+        {"lr_qaoa.json", "metriq_score_1_0.json"} <= suite_names,
+        f"Required bundled suites are missing: found {sorted(suite_names)}",
+    )
+    for name in sorted(suite_names):
+        require(bool(parse_suite_file(name).benchmarks), f"Bundled suite {name} is empty")
+    dashboard = package.joinpath("dashboard", "index.html").read_text(encoding="utf-8")
+    require("<html" in dashboard.lower(), "The packaged dashboard HTML is missing or empty")
+    print(
+        f"Package {__version__}: installed imports, entry point, and resources passed", flush=True
+    )
+    return __version__, cli
+
+
+def run_cli(cli: Path, directory: Path, *args: str) -> str:
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.update(
+        MGYM_LOCAL_DB_DIR=str(directory / "jobs"),
+        MGYM_LOCAL_SIMULATOR_CACHE_DIR=str(directory / "simulator-cache"),
+        NO_COLOR="1",
+        PYTHONIOENCODING="utf-8",
+    )
+    print(f"Running mgym {' '.join(args)}", flush=True)
+    result = subprocess.run(
+        [str(cli), *args],
+        cwd=directory,
+        env=environment,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=180,
+    )
+    # Include both streams in CI logs, including failures with a zero exit code.
+    print(result.stdout, end="", flush=True)
+    print(result.stderr, end="", file=sys.stderr, flush=True)
+    result.check_returncode()
+    return result.stdout
+
+
+def validate_record(record: dict, version: str, suite_id: str | None) -> None:
+    require(record["app_version"] == version, "Result records the wrong package version")
+    require(record["job_type"] == "QML Kernel", "Result records the wrong benchmark")
+    require(record["suite_id"] == suite_id, "Result records the wrong suite ID")
+    require(record["platform"]["provider"] == "local", "Result records the wrong provider")
+    require(record["platform"]["device"] == "aer_simulator", "Result records the wrong device")
+    timestamp = datetime.fromisoformat(record["timestamp"])
+    require(timestamp.utcoffset() == timedelta(0), "Result timestamp is not in UTC")
+    require(not record.get("outcome"), "Benchmark failed instead of producing results")
+    score = record["results"]["accuracy_score"]
+    for name in ("value", "uncertainty"):
+        value = score[name]
+        require(
+            isinstance(value, (int, float)) and math.isfinite(value) and value >= 0,
+            f"Invalid accuracy score {name}: {value}",
+        )
+    require(math.isclose(score["value"], 1.0), f"Unexpected simulator accuracy: {score}")
+
+
+def check_simulator(cli: Path, version: str, directory: Path) -> None:
+    run_cli(cli, directory, "--help")
+    config = {"benchmark_name": "QML Kernel", "num_qubits": 4, "shots": 10}
+    job_config = directory / "job.json"
+    job_config.write_text(json.dumps(config), encoding="utf-8")
+    run_cli(
+        cli, directory, "job", "dispatch", str(job_config), "-p", "local", "-d", "aer_simulator"
+    )
+    job_output = directory / "job-results.json"
+    run_cli(cli, directory, "job", "poll", "latest", "--json", str(job_output))
+    require(job_output.is_file(), "Single-job polling did not produce a JSON file")
+    job_record = json.loads(job_output.read_text(encoding="utf-8"))
+    require(isinstance(job_record, dict), "Single-job polling did not produce a JSON object")
+    validate_record(job_record, version, None)
+
+    suite_config = directory / "suite.json"
+    suite_config.write_text(
+        json.dumps(
+            {
+                "name": "distribution_smoke",
+                "benchmarks": [
+                    {"name": f"qml_kernel_{qubits}q", "config": config | {"num_qubits": qubits}}
+                    for qubits in (4, 3)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    dispatched = run_cli(
+        cli, directory, "suite", "dispatch", str(suite_config), "-p", "local", "-d", "aer_simulator"
+    )
+    match = re.search(r"metriq-gym Suite ID (\S+)", dispatched)
+    if match is None:
+        raise RuntimeError("Suite dispatch did not report a suite ID")
+    suite_id = match.group(1)
+    suite_output = directory / "suite-results.json"
+    run_cli(cli, directory, "suite", "poll", suite_id, "--json", str(suite_output))
+    require(suite_output.is_file(), "Suite polling did not produce a JSON file")
+    records = json.loads(suite_output.read_text(encoding="utf-8"))
+    require(isinstance(records, list) and len(records) == 2, "Expected two suite result records")
+    for record in records:
+        validate_record(record, version, suite_id)
+    require(
+        [record["params"]["num_qubits"] for record in records] == [4, 3],
+        "Suite results lost benchmark parameters or dispatch order",
+    )
+    print("Local simulator: single-job and two-job suite JSON polling passed", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-version", help="Require this exact distribution version")
+    args = parser.parse_args()
+    version, cli = check_package(args.expected_version)
+    with tempfile.TemporaryDirectory(prefix="metriq-gym-smoke-") as directory:
+        check_simulator(cli, version, Path(directory))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_dispatch_poll_suite.py
+++ b/tests/e2e/test_dispatch_poll_suite.py
@@ -20,8 +20,8 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path, local_timezone):
     """
     End-to-end test of the CLI workflow for a suite with two jobs on the local simulator
         1. dispatch   -> returns a Metriq-Gym suite_id and two job_ids
-        2. poll       -> succeeds immediately for the local simulator
-        3. validate   -> JSON result file contains results for both jobs
+        2. poll       -> displays results and exports both jobs to JSON
+        3. upload     -> dry-run payload matches the JSON polling export
     """
 
     # ------------------------------------------------------------------
@@ -74,6 +74,16 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path, local_timezone):
 
     assert "Suite Results" in poll_cmd.stdout, "Suite results not found in poll output"
 
+    json_path = tmp_path / "suite-results.json"
+    subprocess.run(
+        ["mgym", "suite", "poll", suite_id, "--json", str(json_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    poll_records = json.loads(json_path.read_text())
+    assert isinstance(poll_records, list) and len(poll_records) == 2
+
     # ------------------------------------------------------
     # 3. Dry-run suite upload (single PR, no network/git)
     # ------------------------------------------------------
@@ -96,7 +106,7 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path, local_timezone):
 
     with open(path_part) as f:
         arr = json.load(f)
-    assert isinstance(arr, list) and len(arr) == 2
+    assert arr == poll_records
     assert [record["timestamp"] for record in arr] == [
         job.dispatch_time.isoformat() for job in jobs
     ]
@@ -110,6 +120,14 @@ def test_dispatch_and_poll_suite_on_local_simulator(tmp_path, local_timezone):
     for job in job_manager.get_jobs_by_suite_id(suite_id):
         job.dispatch_time = job.dispatch_time.astimezone().replace(tzinfo=None)
         job_manager.update_job(job)
+    legacy_json_path = tmp_path / "legacy-suite-results.json"
+    subprocess.run(
+        ["mgym", "suite", "poll", suite_id, "--json", str(legacy_json_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(legacy_json_path.read_text()) == poll_records
     legacy_upload = subprocess.run(
         ["mgym", "suite", "upload", suite_id, "--dry-run"],
         capture_output=True,

--- a/tests/unit/test_suite_poll.py
+++ b/tests/unit/test_suite_poll.py
@@ -1,0 +1,116 @@
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+from typer.testing import CliRunner
+
+from metriq_gym.cli import app
+from metriq_gym.job_manager import JobManager
+
+
+@pytest.fixture
+def suite_manager(metriq_job, monkeypatch, tmp_path):
+    monkeypatch.setenv("MGYM_LOCAL_DB_DIR", str(tmp_path))
+    manager = JobManager()
+    for index, (width, value, uncertainty) in enumerate([(6, 0.25, None), (7, 0.75, 0.02)]):
+        manager.add_job(
+            replace(
+                metriq_job,
+                id=f"job-{index}",
+                suite_id="suite-1",
+                suite_name="test-suite",
+                params={"benchmark_name": "WIT", "num_qubits": width, "shots": 100},
+                dispatch_time=datetime(2026, 9, 10, 12, index, tzinfo=timezone.utc),
+                runtime_seconds=index + 0.5,
+                result_data={"expectation_value": {"value": value, "uncertainty": uncertainty}},
+            )
+        )
+    return manager
+
+
+def test_suite_poll_json_exports_cached_results_and_metadata(suite_manager, tmp_path):
+    outfile = tmp_path / "suite results.json"
+
+    result = CliRunner().invoke(app, ["suite", "poll", "suite-1", "--json", str(outfile)])
+
+    assert result.exit_code == 0, result.output
+    assert f"Results exported to {outfile}" in result.output
+    records = json.loads(outfile.read_text())
+    assert len(records) == 2
+    for record, job, value, uncertainty in zip(
+        records, suite_manager.get_jobs(), [0.25, 0.75], [None, 0.02]
+    ):
+        assert record["results"] == {
+            "expectation_value": {"value": value, "uncertainty": uncertainty},
+            "score": {"value": value, "uncertainty": uncertainty},
+        }
+        assert record["params"] == job.params
+        assert record["platform"] == job.platform
+        assert record["app_version"] == job.app_version
+        assert record["job_type"] == "WIT"
+        assert record["suite_id"] == "suite-1"
+        assert record["suite"] == {"id": "suite-1", "name": "test-suite"}
+        assert record["timestamp"] == job.dispatch_time.isoformat()
+        assert record["runtime_seconds"] == job.runtime_seconds
+
+
+def test_suite_poll_json_skips_failed_jobs_without_mixing_results(suite_manager, tmp_path):
+    failed = suite_manager.get_job("job-0")
+    failed.result_data = None
+    failed.record_error("dispatch", "Submission failed")
+    suite_manager.update_job(failed)
+    outfile = tmp_path / "suite.json"
+
+    result = CliRunner().invoke(app, ["suite", "poll", "suite-1", "--json", str(outfile)])
+
+    assert result.exit_code == 0, result.output
+    assert "failed; skipping" in result.output
+    records = json.loads(outfile.read_text())
+    assert len(records) == 1
+    assert records[0]["params"]["num_qubits"] == 7
+    assert records[0]["results"]["score"] == {"value": 0.75, "uncertainty": 0.02}
+    assert records[0]["timestamp"] == "2026-09-10T12:01:00+00:00"
+
+
+@pytest.mark.parametrize("existing_file", [False, True])
+def test_suite_poll_json_waits_for_pending_jobs(
+    suite_manager, tmp_path, monkeypatch, existing_file
+):
+    from metriq_gym.run import fetch_result
+
+    pending = suite_manager.get_job("job-1")
+    pending.result_data = None
+    suite_manager.update_job(pending)
+    monkeypatch.setattr(
+        "metriq_gym.run.fetch_result",
+        lambda job, args, manager: (
+            None if job.id == pending.id else fetch_result(job, args, manager)
+        ),
+    )
+    outfile = tmp_path / "suite.json"
+    if existing_file:
+        outfile.write_text("previous export")
+
+    result = CliRunner().invoke(app, ["suite", "poll", "suite-1", "--json", str(outfile)])
+
+    assert result.exit_code == 0, result.output
+    assert "not yet completed" in result.output
+    if existing_file:
+        assert outfile.read_text() == "previous export"
+    else:
+        assert not outfile.exists()
+
+
+def test_suite_poll_json_does_not_export_when_all_jobs_failed(suite_manager, tmp_path):
+    for job in suite_manager.get_jobs():
+        job.result_data = None
+        job.record_error("dispatch", "Submission failed")
+        suite_manager.update_job(job)
+    outfile = tmp_path / "suite.json"
+
+    result = CliRunner().invoke(app, ["suite", "poll", "suite-1", "--json", str(outfile)])
+
+    assert result.exit_code == 0, result.output
+    assert not outfile.exists()
+    assert "Results exported" not in result.output


### PR DESCRIPTION
## Description

`mgym suite poll --json` currently raises `NotImplementedError`, and release workflows publish archives without testing an installed package. This adds suite JSON exports and uses them in a distribution smoke test that gates both PyPI and TestPyPI publishing.

- Suite polling writes an ordered array using the same records as completed suite uploads, including parameters and UTC timestamps. Failed jobs are skipped; pending suites and suites with no completed jobs leave the output file untouched.
- A reusable workflow builds one wheel and source archive, checks metadata and release-tag versions, then installs the wheel on Linux/macOS with Python 3.12/3.13 and the source archive on Linux/Python 3.12.
- The smoke script runs outside the checkout in fresh virtual environments. It checks installed versions/import paths, the CLI entry point, schemas, bundled suites, dashboard HTML and bundled benchmark modules, then dispatches and JSON-polls a tiny local Aer job and two-job suite.
- Publishing downloads the exact tested archives after all smoke jobs pass. CLI and release documentation include behavior and local reproduction instructions.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Validation

- 148 targeted unit tests passed.
- Both timezone variants of the suite simulator end-to-end test passed; JSON exports match dry-run upload records, including legacy local timestamps.
- Built wheel and source archive independently installed into fresh environments on macOS/Python 3.13. Both passed the full installed-package smoke script and `uv pip check`.
- `twine check --strict` passed for both archives.
- 11 version-gate cases passed, including historical prerelease normalization (`v0.5.1-alpha` and `v0.3.0-rc.1`), development builds, mismatched archives and invalid release tags. Existing setuptools_scm configuration and the `v[0-9]*` release-tag filter are unchanged.
- Ruff, formatting, full-project mypy, Actionlint and diff checks passed. GitHub will exercise the full distribution matrix.

The pre-commit per-file mypy and deptry hooks were skipped for previously confirmed baseline failures (`run.py:531` optional score access and the unused `pyqpanda3` declaration). Full-project mypy passes.

## Checklist

- [x] Self-review completed
- [x] Documentation updated
- [x] Regression and installed-distribution tests added
- [x] Targeted existing and new tests pass locally

